### PR TITLE
VDYP-560: Additional updates required to File Upload and Input Parameters UI (1)

### DIFF
--- a/.github/workflows/openshift-dev.yml
+++ b/.github/workflows/openshift-dev.yml
@@ -3,10 +3,10 @@ name: Build and Deploy to Openshift Dev
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "frontend/**"
       - "backend/**"
+      - "charts/app/values-dev.yml"
 concurrency:
   # Cancel if re-attempted
   group: ${{ github.event_name }}

--- a/.github/workflows/openshift-dev.yml
+++ b/.github/workflows/openshift-dev.yml
@@ -36,6 +36,7 @@ jobs:
   deploys:
     name: Deploys
     needs: [builds]
+    if: ${{ github.head_ref != 'feature/frontend-updates' }}
     uses: ./.github/workflows/.deployer.yml
     secrets:
       inherit

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -68,10 +68,10 @@ spec:
             timeoutSeconds: 5
           resources: # this is optional
             limits:
-              cpu: 50m
+              cpu: 250m
               memory: 250Mi
             requests:
-              cpu: 20m
+              cpu: 50m
               memory: 150Mi
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -9,7 +9,7 @@ global:
   #-- the tag of the image, it can be latest, 1.0.0 etc..., or the sha256 hash
   tag: ~
   #-- turn off autoscaling for the entire suite by setting this to false. default is true.
-  autoscaling: false
+  autoscaling: true
   #-- global secrets, can be accessed by sub-charts.
   secrets:
     enabled: true
@@ -32,9 +32,9 @@ backend:
     #-- enable or disable autoscaling.
     enabled: true
     #-- the minimum number of replicas.
-    minReplicas: 3
+    minReplicas: 1
     #-- the maximum number of replicas.
-    maxReplicas: 7
+    maxReplicas: 3
     #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
     targetCPUUtilizationPercentage: 80
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
@@ -54,7 +54,7 @@ backend:
     #-- resources specific to vault initContainer. it is optional and is an object.
     resources:
       limits:
-        cpu: 50m
+        cpu: 250m
         memory: 50Mi
       requests:
         cpu: 50m

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -107,6 +107,7 @@ frontend:
         name: metrics
   ingress:
     annotations:
+      haproxy.router.openshift.io/timeout: 300s # 5min
       route.openshift.io/termination: "edge"
   pdb:
     enabled: false # enable it in PRODUCTION for having pod disruption budget.

--- a/frontend/cypress/e2e/unit/fileUploadService.cy.ts
+++ b/frontend/cypress/e2e/unit/fileUploadService.cy.ts
@@ -1,0 +1,136 @@
+/// <reference types="cypress" />
+
+import {
+  getSelectedExecutionOptions,
+  getSelectedDebugOptions,
+  getFormData,
+  runModelFileUpload,
+} from '@/services/fileUploadService'
+import { useFileUploadStore } from '@/stores/fileUploadStore'
+import {
+  SelectedExecutionOptionsEnum,
+  SelectedDebugOptionsEnum,
+  ParameterNamesEnum,
+  OutputFormatEnum,
+  CombineAgeYearRangeEnum,
+  MetadataToOutputEnum,
+} from '@/services/vdyp-api'
+import * as apiActions from '@/services/apiActions'
+import { CONSTANTS } from '@/constants'
+import { createPinia, setActivePinia } from 'pinia'
+import sinon, { SinonStub } from 'sinon'
+
+describe('File Upload Service Unit Tests', () => {
+  let fileUploadStore: ReturnType<typeof useFileUploadStore>
+  let projectionStub: SinonStub<[FormData, boolean?], Promise<any>>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fileUploadStore = useFileUploadStore()
+
+    fileUploadStore.projectionType = CONSTANTS.PROJECTION_TYPE.VOLUME
+    fileUploadStore.includeInReport = [
+      CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
+    ]
+    fileUploadStore.startingAge = 10
+    fileUploadStore.finishingAge = 100
+    fileUploadStore.ageIncrement = 10
+    fileUploadStore.polygonFile = new File(['polygon content'], 'polygon.csv', {
+      type: 'text/csv',
+    })
+    fileUploadStore.layerFile = new File(['layer content'], 'layer.csv', {
+      type: 'text/csv',
+    })
+
+    projectionStub = sinon
+      .stub(apiActions, 'projectionHcsvPost')
+      .resolves(new Blob(['mock response'], { type: 'application/json' }))
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should return correct selected execution options for volume projection', () => {
+    const options = getSelectedExecutionOptions(fileUploadStore)
+    expect(options).to.include.members([
+      SelectedExecutionOptionsEnum.ForwardGrowEnabled,
+      SelectedExecutionOptionsEnum.DoIncludeFileHeader,
+      SelectedExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
+      SelectedExecutionOptionsEnum.DoIncludeSpeciesProjection,
+    ])
+  })
+
+  it('should return correct selected execution options for CFS biomass projection', () => {
+    fileUploadStore.projectionType = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
+    fileUploadStore.includeInReport = []
+    const options = getSelectedExecutionOptions(fileUploadStore)
+    expect(options).to.include(
+      SelectedExecutionOptionsEnum.DoIncludeProjectedCFSBiomass,
+    )
+    expect(options).not.to.include(
+      SelectedExecutionOptionsEnum.DoIncludeSpeciesProjection,
+    )
+  })
+
+  it('should return default selected debug options', () => {
+    const debugOptions = getSelectedDebugOptions()
+    expect(debugOptions).to.deep.equal([
+      SelectedDebugOptionsEnum.DoIncludeDebugTimestamps,
+      SelectedDebugOptionsEnum.DoIncludeDebugEntryExit,
+      SelectedDebugOptionsEnum.DoIncludeDebugIndentBlocks,
+      SelectedDebugOptionsEnum.DoIncludeDebugRoutineNames,
+    ])
+  })
+
+  it('should create form data with correct parameters', () => {
+    const formData = getFormData(fileUploadStore)
+
+    expect(formData.has(ParameterNamesEnum.PROJECTION_PARAMETERS)).to.be.true
+    expect(formData.has(ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA)).to.be.true
+    expect(formData.has(ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA)).to.be.true
+
+    const projectionParamsBlob = formData.get(
+      ParameterNamesEnum.PROJECTION_PARAMETERS,
+    ) as Blob
+    cy.wrap(projectionParamsBlob.text()).then((text: string) => {
+      const projectionParams = JSON.parse(text)
+      expect(projectionParams.ageStart).to.equal(10)
+      expect(projectionParams.ageEnd).to.equal(100)
+      expect(projectionParams.ageIncrement).to.equal(10)
+      expect(projectionParams.outputFormat).to.equal(
+        OutputFormatEnum.CSVYieldTable,
+      )
+      expect(projectionParams.combineAgeYearRange).to.equal(
+        CombineAgeYearRangeEnum.Intersect,
+      )
+      expect(projectionParams.metadataToOutput).to.equal(
+        MetadataToOutputEnum.VERSION,
+      )
+      expect(projectionParams.selectedExecutionOptions).to.include(
+        SelectedExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
+      )
+    })
+  })
+
+  it('should call projectionHcsvPost with correct form data', async () => {
+    await runModelFileUpload(fileUploadStore)
+    expect(projectionStub.calledOnce).to.be.true
+    const formDataArg = projectionStub.getCall(0).args[0] as FormData
+    expect(formDataArg.has(ParameterNamesEnum.PROJECTION_PARAMETERS)).to.be.true
+    expect(formDataArg.has(ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA)).to.be
+      .true
+    expect(formDataArg.has(ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA)).to.be
+      .true
+  })
+
+  it('should handle projectionHcsvPost failure', async () => {
+    projectionStub.rejects(new Error('API call failed'))
+    try {
+      await runModelFileUpload(fileUploadStore)
+    } catch (error) {
+      expect(error).to.be.an('error')
+      expect(error.message).to.equal('API call failed')
+    }
+  })
+})

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -59,6 +59,11 @@ export const MODEL_PARAMETER_PANEL = Object.freeze({
   REPORT_INFO: 'reportInfo',
 })
 
+export const FILE_UPLOAD_PANEL = Object.freeze({
+  REPORT_INFO: 'reportInfo',
+  ATTACHMENTS: 'attachments',
+})
+
 export const NUM_INPUT_LIMITS = Object.freeze({
   SPECIES_PERCENT_MAX: 100,
   SPECIES_PERCENT_MIN: 0,
@@ -110,7 +115,7 @@ export const MESSAGE_TYPE = Object.freeze({
 
 export const HEADER_SELECTION = Object.freeze({
   MODEL_PARAMETER_SELECTION: 'Model Parameter Selection',
-  FILE_UPLOAD: 'File upload',
+  FILE_UPLOAD: 'File Upload',
 })
 
 export const MODEL_SELECTION = Object.freeze({
@@ -119,14 +124,14 @@ export const MODEL_SELECTION = Object.freeze({
 })
 
 export const MODEL_PARAM_TAB_NAME = Object.freeze({
-  MODEL_PARAM_SELECTION: 'Model Parameter Selection',
+  MODEL_PARAM_SELECTION: 'Parameter Selection',
   MODEL_REPORT: 'Model Report',
   VIEW_LOG_FILE: 'View Log File',
   VIEW_ERROR_MESSAGES: 'View Error Messages',
 })
 
 export const FILE_UPLOAD_TAB_NAME = Object.freeze({
-  FILE_UPLOAD: 'File Upload',
+  FILE_UPLOAD: 'Parameter Selection',
   MODEL_REPORT: 'Model Report',
   VIEW_LOG_FILE: 'View Log File',
   VIEW_ERROR_MESSAGES: 'View Error Messages',

--- a/frontend/src/services/fileUploadService.ts
+++ b/frontend/src/services/fileUploadService.ts
@@ -1,0 +1,107 @@
+import { useFileUploadStore } from '@/stores/fileUploadStore'
+import { CONSTANTS } from '@/constants'
+import {
+  OutputFormatEnum,
+  SelectedExecutionOptionsEnum,
+  SelectedDebugOptionsEnum,
+  MetadataToOutputEnum,
+  CombineAgeYearRangeEnum,
+  ParameterNamesEnum,
+} from '@/services/vdyp-api'
+import { projectionHcsvPost } from '@/services/apiActions'
+
+export const getSelectedExecutionOptions = (
+  fileUploadStore: ReturnType<typeof useFileUploadStore>,
+) => {
+  const selectedExecutionOptions = [
+    SelectedExecutionOptionsEnum.ForwardGrowEnabled,
+    SelectedExecutionOptionsEnum.DoIncludeFileHeader,
+    SelectedExecutionOptionsEnum.DoIncludeProjectionModeInYieldTable,
+    SelectedExecutionOptionsEnum.DoIncludeAgeRowsInYieldTable,
+    SelectedExecutionOptionsEnum.DoIncludeYearRowsInYieldTable,
+    SelectedExecutionOptionsEnum.DoSummarizeProjectionByLayer,
+    SelectedExecutionOptionsEnum.DoIncludeColumnHeadersInYieldTable,
+    SelectedExecutionOptionsEnum.DoAllowBasalAreaAndTreesPerHectareValueSubstitution,
+    SelectedExecutionOptionsEnum.DoEnableProgressLogging,
+    SelectedExecutionOptionsEnum.DoEnableErrorLogging,
+    SelectedExecutionOptionsEnum.DoEnableDebugLogging,
+  ]
+
+  if (fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.VOLUME) {
+    selectedExecutionOptions.push(
+      SelectedExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
+    )
+  } else if (
+    fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
+  ) {
+    selectedExecutionOptions.push(
+      SelectedExecutionOptionsEnum.DoIncludeProjectedCFSBiomass,
+    )
+  }
+
+  if (
+    fileUploadStore.includeInReport &&
+    fileUploadStore.includeInReport.includes(
+      CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
+    )
+  ) {
+    selectedExecutionOptions.push(
+      SelectedExecutionOptionsEnum.DoIncludeSpeciesProjection,
+    )
+  }
+
+  return selectedExecutionOptions
+}
+
+export const getSelectedDebugOptions = () => {
+  const selectedDebugOptions: Array<SelectedDebugOptionsEnum> = [
+    SelectedDebugOptionsEnum.DoIncludeDebugTimestamps,
+    SelectedDebugOptionsEnum.DoIncludeDebugEntryExit,
+    SelectedDebugOptionsEnum.DoIncludeDebugIndentBlocks,
+    SelectedDebugOptionsEnum.DoIncludeDebugRoutineNames,
+  ]
+
+  return selectedDebugOptions
+}
+
+export const getFormData = (
+  fileUploadStore: ReturnType<typeof useFileUploadStore>,
+) => {
+  const projectionParameters = {
+    ageStart: fileUploadStore.startingAge,
+    ageEnd: fileUploadStore.finishingAge,
+    ageIncrement: fileUploadStore.ageIncrement,
+    outputFormat: OutputFormatEnum.CSVYieldTable,
+    selectedExecutionOptions: getSelectedExecutionOptions(fileUploadStore),
+    selectedDebugOptions: getSelectedDebugOptions(),
+    combineAgeYearRange: CombineAgeYearRangeEnum.Intersect,
+    metadataToOutput: MetadataToOutputEnum.VERSION,
+  }
+
+  const formData = new FormData()
+
+  formData.append(
+    ParameterNamesEnum.PROJECTION_PARAMETERS,
+    new Blob([JSON.stringify(projectionParameters)], {
+      type: 'application/json',
+    }),
+  )
+  formData.append(
+    ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA,
+    fileUploadStore.polygonFile as Blob,
+  )
+  formData.append(
+    ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA,
+    fileUploadStore.layerFile as Blob,
+  )
+
+  return formData
+}
+
+export const runModelFileUpload = async (
+  fileUploadStore: ReturnType<typeof useFileUploadStore>,
+) => {
+  const formData = getFormData(fileUploadStore)
+  const response = await projectionHcsvPost(formData, false)
+  return response
+}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { DEFAULTS } from '@/constants'
+
+export const useAppStore = defineStore('appStore', () => {
+  const modelSelection = ref<string>(DEFAULTS.DEFAULT_VALUES.MODEL_SELECTION)
+
+  const getModelSelection = computed(() => modelSelection.value)
+
+  const setModelSelection = (newSelection: string) => {
+    modelSelection.value = newSelection
+  }
+
+  return {
+    modelSelection,
+    getModelSelection,
+    setModelSelection,
+  }
+})

--- a/frontend/src/stores/fileUploadStore.ts
+++ b/frontend/src/stores/fileUploadStore.ts
@@ -1,0 +1,117 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { CONSTANTS, DEFAULTS } from '@/constants'
+import type { FileUploadPanelName, PanelState } from '@/types/types'
+
+export const useFileUploadStore = defineStore('fileUploadStore', () => {
+  // panel open
+  const panelOpenStates = ref<Record<FileUploadPanelName, PanelState>>({
+    reportInfo: CONSTANTS.PANEL.OPEN,
+    attachments: CONSTANTS.PANEL.CLOSE,
+  })
+
+  // Panel states for confirming and editing
+  const panelState = ref<
+    Record<FileUploadPanelName, { confirmed: boolean; editable: boolean }>
+  >({
+    reportInfo: { confirmed: false, editable: true },
+    attachments: { confirmed: false, editable: false },
+  })
+
+  const runModelEnabled = ref(false)
+
+  // Method to handle confirm action for each panel
+  const confirmPanel = (panelName: FileUploadPanelName) => {
+    panelState.value[panelName].confirmed = true
+    panelState.value[panelName].editable = false
+
+    // Enable the next panel's confirm and clear buttons
+    const panelOrder: FileUploadPanelName[] = [
+      CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO,
+      CONSTANTS.FILE_UPLOAD_PANEL.ATTACHMENTS,
+    ]
+    const currentIndex = panelOrder.indexOf(panelName)
+    if (currentIndex !== -1 && currentIndex < panelOrder.length - 1) {
+      // The next panel opens automatically, switching to the editable.
+      const nextPanel = panelOrder[currentIndex + 1]
+      panelOpenStates.value[nextPanel] = CONSTANTS.PANEL.OPEN
+      panelState.value[nextPanel].editable = true
+    }
+
+    // Check if all panels are confirmed to enable the 'Run Model' button
+    runModelEnabled.value = panelOrder.every(
+      (panel) => panelState.value[panel].confirmed,
+    )
+  }
+
+  // Method to handle edit action for each panel
+  const editPanel = (panelName: FileUploadPanelName) => {
+    panelState.value[panelName].confirmed = false
+    panelState.value[panelName].editable = true
+
+    // Disable all subsequent panels
+    const panelOrder: FileUploadPanelName[] = [
+      CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO,
+      CONSTANTS.FILE_UPLOAD_PANEL.ATTACHMENTS,
+    ]
+    const currentIndex = panelOrder.indexOf(panelName)
+    if (currentIndex !== -1) {
+      for (let i = currentIndex + 1; i < panelOrder.length; i++) {
+        // All of the next panels are automatically closed, uneditable, and unconfirmed
+        const nextPanel = panelOrder[i]
+        panelState.value[nextPanel].confirmed = false
+        panelState.value[nextPanel].editable = false
+        panelOpenStates.value[nextPanel] = CONSTANTS.PANEL.CLOSE
+      }
+    }
+
+    // Disable 'Run Model' button
+    runModelEnabled.value = false
+  }
+
+  // report info
+  const startingAge = ref<number | null>(null)
+  const finishingAge = ref<number | null>(null)
+  const ageIncrement = ref<number | null>(null)
+  const volumeReported = ref<string[]>([])
+  const includeInReport = ref<string[]>([])
+  const projectionType = ref<string | null>(null)
+  const reportTitle = ref<string | null>(null)
+
+  // attachments
+  const polygonFile = ref<File | null>(null)
+  const layerFile = ref<File | null>(null)
+
+  // set default values
+  const setDefaultValues = () => {
+    startingAge.value = DEFAULTS.DEFAULT_VALUES.STARTING_AGE
+    finishingAge.value = DEFAULTS.DEFAULT_VALUES.FINISHING_AGE
+    ageIncrement.value = DEFAULTS.DEFAULT_VALUES.AGE_INCREMENT
+    volumeReported.value = DEFAULTS.DEFAULT_VALUES.VOLUME_REPORTED
+    projectionType.value = DEFAULTS.DEFAULT_VALUES.PROJECTION_TYPE
+    reportTitle.value = DEFAULTS.DEFAULT_VALUES.REPORT_TITLE
+  }
+
+  return {
+    // panel open
+    panelOpenStates,
+    // Panel state
+    panelState,
+    runModelEnabled,
+    confirmPanel,
+    editPanel,
+    // report info
+    startingAge,
+    finishingAge,
+    ageIncrement,
+    volumeReported,
+    includeInReport,
+    projectionType,
+    reportTitle,
+    // attachments
+    polygonFile,
+    layerFile,
+    // set default values
+    setDefaultValues,
+  }
+})

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,6 +1,7 @@
 import {
   PANEL,
   MODEL_PARAMETER_PANEL,
+  FILE_UPLOAD_PANEL,
   SORT_ORDER,
   MESSAGE_TYPE,
   REPORTING_TAB,
@@ -18,6 +19,10 @@ export type PanelName =
   | typeof MODEL_PARAMETER_PANEL.SITE_INFO
   | typeof MODEL_PARAMETER_PANEL.STAND_DENSITY
   | typeof MODEL_PARAMETER_PANEL.REPORT_INFO
+
+export type FileUploadPanelName =
+  | typeof FILE_UPLOAD_PANEL.REPORT_INFO
+  | typeof FILE_UPLOAD_PANEL.ATTACHMENTS
 
 export type PanelState = typeof PANEL.OPEN | typeof PANEL.CLOSE
 


### PR DESCRIPTION
- VDYP-560, fileUploadService and fileUploadService unit test
- Update CPU max for API / remove pr types / add path to include charts / enable global.autoscaling to apply minReplicas and maxReplicas of backend and to create HPA resource 
- Set proxy timeout 5min
- Temporarily exclude feature/frontend-update branch deployments to avoid breaking testing because the DEV backend does not work