### PR TITLE
VDYP-572: Fix for crash when a control file has a zero length value

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,7 +26,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -35,7 +35,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-vri</artifactId>
 			<version>${project.version}</version>
-			<classifier>vri-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -50,7 +50,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-fip</artifactId>
 			<version>${project.version}</version>
-			<classifier>fip-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/integration-tests/src/test/resources/ca/bc/gov/nrs/vdyp/integration_tests/example_vri/skip
+++ b/integration-tests/src/test/resources/ca/bc/gov/nrs/vdyp/integration_tests/example_vri/skip
@@ -1,2 +1,2 @@
-testVriStart
 testVdypForward
+testVriStart

--- a/lib/vdyp-common/pom.xml
+++ b/lib/vdyp-common/pom.xml
@@ -92,7 +92,7 @@
 								<goal>test-jar</goal>
 							</goals>
 							<configuration>
-								<classifier>common-test-jar</classifier>
+								<classifier>tests</classifier>
 							</configuration>
 						</execution>
 					</executions>

--- a/lib/vdyp-common/src/main/java/ca/bc/gov/nrs/vdyp/io/parse/control/ControlFileParser.java
+++ b/lib/vdyp-common/src/main/java/ca/bc/gov/nrs/vdyp/io/parse/control/ControlFileParser.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import ca.bc.gov.nrs.vdyp.common.ControlKey;
+import ca.bc.gov.nrs.vdyp.common.Utils;
 import ca.bc.gov.nrs.vdyp.io.parse.common.LineParser;
 import ca.bc.gov.nrs.vdyp.io.parse.common.ResourceParseException;
 import ca.bc.gov.nrs.vdyp.io.parse.common.ResourceParser;
@@ -96,7 +97,7 @@ public class ControlFileParser implements ResourceParser<Map<String, Object>> {
 		result = lineParser.parse(input, result, (map, r, line) -> {
 			Integer index = (Integer) map.get("index");
 			String extend = (String) map.get("extend");
-			String restOfLine = (String) map.get("restOfLine");
+			String restOfLine = Utils.<String>optSafe(map.get("restOfLine")).orElse("");
 
 			// How long is the control value
 			int controlLength = Math

--- a/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/io/parse/control/ControlFileParserTest.java
+++ b/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/io/parse/control/ControlFileParserTest.java
@@ -180,6 +180,30 @@ class ControlFileParserTest {
 	}
 
 	@Test
+	void testParsesEntriesEmptyContent() throws Exception {
+		var parser = makeParser();
+
+		String file = "015 \n";
+		try (InputStream is = new ByteArrayInputStream(file.getBytes())) {
+			var result = parser.parse(is);
+
+			assertThat(result.entrySet(), contains(controlEntry(equalTo(15), equalTo(" "), equalTo(""))));
+		}
+	}
+
+	@Test
+	void testParsesEntriesEmptyContentExtended() throws Exception {
+		var parser = makeParser();
+
+		String file = "016X\n";
+		try (InputStream is = new ByteArrayInputStream(file.getBytes())) {
+			var result = parser.parse(is);
+
+			assertThat(result.entrySet(), contains(controlEntry(equalTo(16), equalTo("X"), equalTo(""))));
+		}
+	}
+
+	@Test
 	void testParsesMultipleEntries() throws Exception {
 		var parser = makeParser();
 

--- a/lib/vdyp-fip/pom.xml
+++ b/lib/vdyp-fip/pom.xml
@@ -26,7 +26,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -114,7 +114,7 @@
 								<goal>test-jar</goal>
 							</goals>
 							<configuration>
-								<classifier>fip-test-jar</classifier>
+								<classifier>tests</classifier>
 							</configuration>
 						</execution>
 					</executions>

--- a/lib/vdyp-forward/pom.xml
+++ b/lib/vdyp-forward/pom.xml
@@ -25,7 +25,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/lib/vdyp-si32/pom.xml
+++ b/lib/vdyp-si32/pom.xml
@@ -63,7 +63,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/lib/vdyp-vri/pom.xml
+++ b/lib/vdyp-vri/pom.xml
@@ -26,7 +26,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -119,7 +119,7 @@
 								<goal>test-jar</goal>
 							</goals>
 							<configuration>
-								<classifier>vri-test-jar</classifier>
+								<classifier>tests</classifier>
 							</configuration>
 						</execution>
 					</executions>

--- a/vdyp-test-oracle/pom.xml
+++ b/vdyp-test-oracle/pom.xml
@@ -26,7 +26,7 @@
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
 			<version>${project.version}</version>
-			<classifier>common-test-jar</classifier>
+			<classifier>tests</classifier>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/VDYP-572