### PR TITLE
VDYP-589: Remove Concurrency check in shared job to prevent deadlock

### DIFF
--- a/.github/workflows/openshift-shared.yml
+++ b/.github/workflows/openshift-shared.yml
@@ -11,11 +11,6 @@ on:
         required: false
         type: string
 
-concurrency:
-  # Cancel if re-attempted
-  group: ${{ github.event_name }}
-  cancel-in-progress: true
-
 jobs:
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:


### PR DESCRIPTION
Duplicate Concurrency in caller and callee creates deadlock