### PR TITLE
Feature/vdyp 659

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/Parameters.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/Parameters.java
@@ -176,7 +176,8 @@ public class Parameters {
 		DO_ENABLE_PROGRESS_LOGGING("doEnableProgressLogging"), //
 		DO_ENABLE_ERROR_LOGGING("doEnableErrorLogging"), //
 		DO_ENABLE_DEBUG_LOGGING("doEnableDebugLogging"), //
-		DO_DELAY_EXECUTION_FOLDER_DELETION("doDelayExecutionFolderDeletion");
+		DO_DELAY_EXECUTION_FOLDER_DELETION("doDelayExecutionFolderDeletion"),
+		ALLOW_AGGRESSIVE_VALUE_ESTIMATION("allowAggressiveValueEstimation");
 
 		private String value;
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -613,7 +613,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 			}
 		}
 
-		sp64.calculateUndefinedFieldValues();
+		sp64.calculateUndefinedFieldValues(context);
 
 		stand.addSp64(sp64);
 		layer.addSp64(sp64);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
@@ -17,7 +17,6 @@ import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexAgeType;
 import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexEquation;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.PolygonValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.MessageSeverityCode;
-import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.PolygonMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
@@ -526,7 +525,7 @@ public class Layer implements Comparable<Layer> {
 					);
 				}
 
-				sp64.calculateUndefinedFieldValues();
+				sp64.calculateUndefinedFieldValues(context);
 
 				if (doRecomputeInputHeight) {
 
@@ -647,7 +646,7 @@ public class Layer implements Comparable<Layer> {
 
 				if (Utils.safeGet(s.getTotalAge()) >= 30.0 && s.getDominantHeight() != null) {
 
-					s.calculateUndefinedFieldValues();
+					s.calculateUndefinedFieldValues(context);
 
 					estimatedSiteIndex = s.getSiteIndex();
 					estimatedSiteIndexSpeciesCode = s.getSpeciesCode();
@@ -795,9 +794,9 @@ public class Layer implements Comparable<Layer> {
 		if (crownClosure == null) {
 			boolean getLeadingSpeciesDefault = false;
 			Species leadingSp64 = null;
-			boolean doAggresiveEstimation = context.getParams()
-					.containsOption(Parameters.ExecutionOption.ALLOW_AGGRESSIVE_VALUE_ESTIMATION)
-					&& this == polygon.getLayerByProjectionType(ProjectionTypeCode.PRIMARY);
+			boolean doAggresiveEstimation = false;// context.getParams()
+			// .containsOption(Parameters.ExecutionOption.ALLOW_AGGRESSIVE_VALUE_ESTIMATION)
+			// && this == polygon.getLayerByProjectionType(ProjectionTypeCode.PRIMARY);
 
 			if (this == polygon.getLayerByProjectionType(ProjectionTypeCode.UNKNOWN) || doAggresiveEstimation) {
 				leadingSp64 = this.determineLeadingSp64(0);
@@ -1275,7 +1274,7 @@ public class Layer implements Comparable<Layer> {
 	 *
 	 * @throws PolygonValidationException
 	 */
-	void doCompleteSiteSpeciesSiteIndexInfo() throws PolygonValidationException {
+	void doCompleteSiteSpeciesSiteIndexInfo(ProjectionContext context) throws PolygonValidationException {
 
 		boolean amDone = false;
 
@@ -1325,7 +1324,7 @@ public class Layer implements Comparable<Layer> {
 
 			} else {
 
-				siteSpecies.calculateUndefinedFieldValues();
+				siteSpecies.calculateUndefinedFieldValues(context);
 				speciesGroup.setSiteCurve(siteSpecies.getSiteCurve());
 			}
 		}
@@ -1342,7 +1341,7 @@ public class Layer implements Comparable<Layer> {
 						&& !siteSpecies.getSpeciesCode().equals(candidateDonorSpecies.getSpeciesCode())) {
 
 					if (candidateDonorSpecies.getSiteIndex() == null) {
-						candidateDonorSpecies.calculateUndefinedFieldValues();
+						candidateDonorSpecies.calculateUndefinedFieldValues(context);
 					}
 
 					donorSpecies = candidateDonorSpecies;
@@ -1409,14 +1408,14 @@ public class Layer implements Comparable<Layer> {
 
 				// Now reset dominant height and recompute it from the values assigned above.
 				siteSpecies.resetDominantHeight();
-				siteSpecies.calculateUndefinedFieldValues();
+				siteSpecies.calculateUndefinedFieldValues(context);
 
 				amDone = true;
 			}
 
 			if (amDone && stand != null && siteSpecies != null) {
 				speciesGroup.updateSiteInfo(siteSpecies);
-				speciesGroup.calculateUndefinedFieldValues();
+				speciesGroup.calculateUndefinedFieldValues(context);
 			}
 		}
 	}

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
@@ -554,6 +554,7 @@ public class Layer implements Comparable<Layer> {
 					sp0.setDominantHeight(sp64.getDominantHeight());
 					sp0.setSiteIndex(sp64.getSiteIndex());
 					sp0.setTotalAge(sp64.getTotalAge());
+					sp0.setYearsToBreastHeight(sp64.getYearsToBreastHeight());
 					sp0.setSiteCurve(sp64.getSiteCurve());
 				}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
@@ -17,6 +17,7 @@ import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexAgeType;
 import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexEquation;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.PolygonValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.MessageSeverityCode;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.PolygonMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
@@ -794,9 +795,9 @@ public class Layer implements Comparable<Layer> {
 		if (crownClosure == null) {
 			boolean getLeadingSpeciesDefault = false;
 			Species leadingSp64 = null;
-			boolean doAggresiveEstimation = false;// context.getParams()
-			// .containsOption(Parameters.ExecutionOption.ALLOW_AGGRESSIVE_VALUE_ESTIMATION)
-			// && this == polygon.getLayerByProjectionType(ProjectionTypeCode.PRIMARY);
+			boolean doAggresiveEstimation = context.getParams()
+					.containsOption(Parameters.ExecutionOption.ALLOW_AGGRESSIVE_VALUE_ESTIMATION)
+					&& this == polygon.getLayerByProjectionType(ProjectionTypeCode.PRIMARY);
 
 			if (this == polygon.getLayerByProjectionType(ProjectionTypeCode.UNKNOWN) || doAggresiveEstimation) {
 				leadingSp64 = this.determineLeadingSp64(0);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Layer.java
@@ -822,7 +822,7 @@ public class Layer implements Comparable<Layer> {
 						).build()
 				);
 
-			} else if (leadingSp64 == null) {
+			} else if (this == polygon.getLayerByProjectionType(ProjectionTypeCode.UNKNOWN) && leadingSp64 == null) {
 				getPolygon().disableProjectionsOfType(assignedProjectionType);
 
 				getPolygon().addMessage(
@@ -833,15 +833,15 @@ public class Layer implements Comparable<Layer> {
 								).build()
 				);
 				logger.debug("Disabling projections of type {}", assignedProjectionType);
-			}
-		} else if (this == polygon.getLayerByProjectionType(ProjectionTypeCode.VETERAN)) {
-			// this is the veteran layer
+			} else if (this == polygon.getLayerByProjectionType(ProjectionTypeCode.VETERAN)) {
+				// this is the veteran layer
 
-			short estimatedCrownClosure = 4;
-			logger.debug("{}: estimating crown closure of veteran layer at {}", this, estimatedCrownClosure);
-			crownClosure = estimatedCrownClosure;
-		} else {
-			// do nothing - no need to estimate crown closure for non-primary, non-veteran layer
+				short estimatedCrownClosure = 4;
+				logger.debug("{}: estimating crown closure of veteran layer at {}", this, estimatedCrownClosure);
+				crownClosure = estimatedCrownClosure;
+			} else {
+				// do nothing - no need to estimate crown closure for non-primary, non-veteran layer
+			}
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -1032,7 +1032,13 @@ public class Polygon implements Comparable<Polygon> {
 			);
 		}
 
-		var crownClosure = Math.max(0.0, primaryLayer.getCrownClosure());
+		short crownClosure = 0;
+		if (primaryLayer != null) {
+			NullMath.max(
+					crownClosure, primaryLayer.getCrownClosure(), (a, b) -> (short) Math.max(a, b),
+					Vdyp7Constants.EMPTY_SHORT
+			);
+		}
 		logger.debug(
 				"{}: crown closure: primary layer crown closure: {}; value used: {}", primaryLayer.getCrownClosure(),
 				crownClosure

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -667,7 +667,7 @@ public class Polygon implements Comparable<Polygon> {
 
 		for (Layer layer : getLayers().values()) {
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 		}
 
 		var rGrowthModel = new Reference<GrowthModelCode>();

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -1032,12 +1032,9 @@ public class Polygon implements Comparable<Polygon> {
 			);
 		}
 
-		short crownClosure = 0;
-		if (primaryLayer != null) {
-			NullMath.max(
-					crownClosure, primaryLayer.getCrownClosure(), (a, b) -> (short) Math.max(a, b),
-					Vdyp7Constants.EMPTY_SHORT
-			);
+		var crownClosure = 0;
+		if (primaryLayer != null && primaryLayer.getCrownClosure() != null) {
+			crownClosure = (short) Math.max(crownClosure, primaryLayer.getCrownClosure());
 		}
 		logger.debug(
 				"{}: crown closure: primary layer crown closure: {}; value used: {}", primaryLayer.getCrownClosure(),

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -1035,11 +1035,11 @@ public class Polygon implements Comparable<Polygon> {
 		var crownClosure = 0;
 		if (primaryLayer != null && primaryLayer.getCrownClosure() != null) {
 			crownClosure = (short) Math.max(crownClosure, primaryLayer.getCrownClosure());
+			logger.debug(
+					"{}: crown closure: primary layer crown closure: {}; value used: {}", primaryLayer,
+					primaryLayer.getCrownClosure(), crownClosure
+			);
 		}
-		logger.debug(
-				"{}: crown closure: primary layer crown closure: {}; value used: {}", primaryLayer.getCrownClosure(),
-				crownClosure
-		);
 
 		var ccFullyStocked = isCoastal ? Vdyp7Constants.CC_COAST : Vdyp7Constants.CC_INTERIOR;
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -1081,8 +1081,9 @@ public class Polygon implements Comparable<Polygon> {
 			var percentAbsorbable = estimatedPercentStockable + percentNonStockable + percentUnaccounted;
 			double percentStockableAbsorbable, percentUnaccountedAbsorbable;
 			if (percentAbsorbable > 0) {
-				percentStockableAbsorbable = percentCrownSpaces * (estimatedPercentStockable / percentAbsorbable);
-				percentUnaccountedAbsorbable = percentCrownSpaces * (percentUnaccounted / percentAbsorbable);
+				percentStockableAbsorbable = percentCrownSpaces
+						* ((double) estimatedPercentStockable / percentAbsorbable);
+				percentUnaccountedAbsorbable = percentCrownSpaces * ((double) percentUnaccounted / percentAbsorbable);
 			} else {
 				percentStockableAbsorbable = 0;
 				percentUnaccountedAbsorbable = 0;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
@@ -571,9 +571,26 @@ public class Species implements Comparable<Species> {
 				 * associated site index value but no age/height pair. Based on e-mails and conversations with Cam
 				 * today, we need to consider and perform the following: - The underlying models require an age (but not
 				 * height) - The BHAge will be assumed to be 1.0 - Total Age will be determined from this.
+				 *
+				 * Note for VDYP8 like for like. While that age is calculated and passed in as the age to use it is
+				 * truncated to the closest short because that is how the engine treats estimated age, do not actually
+				 * SET ageAtBreastHeight to 1. use that value to calculate an age and then use that age as though it
+				 * were passed in
+				 * 
 				 */
 				keepTrying = true;
-				ageAtBreastHeight = 1.0;
+				var ageAtBreastHeightRef = new Reference<Double>(1.0);
+				var yearsToBreastHeightRef = new Reference<Double>(yearsToBreastHeight);
+				var computedTotalAgeRef = new Reference<Double>(Vdyp7Constants.EMPTY_DECIMAL);
+
+				SiteTool.fillInAgeTriplet(computedTotalAgeRef, ageAtBreastHeightRef, yearsToBreastHeightRef);
+
+				haveComputedTotalAge = true;
+				totalAge = Math.floor(computedTotalAgeRef.get());
+				logger.debug(
+						"{}: using WinVDYP estimation technique assuming age at Breast Height 1.0 to calculate a total age of {}",
+						this, totalAge
+				);
 			}
 		}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
@@ -554,7 +554,7 @@ public class Species implements Comparable<Species> {
 
 				SiteTool.fillInAgeTriplet(computedTotalAgeRef, ageAtBreastHeightRef, yearsToBreastHeightRef);
 
-				setAgeAtBreastHeight(yearsToBreastHeightRef.get());
+				setAgeAtBreastHeight(ageAtBreastHeightRef.get());
 
 				keepTrying = true;
 				haveComputedAgeAtBreastHeight = true;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
@@ -567,10 +567,10 @@ public class Species implements Comparable<Species> {
 					&& ageAtBreastHeight == null && totalAge == null && dominantHeight == null && siteIndex != null
 					&& yearsToBreastHeight != null) {
 				/*
-				 * 2004/03/17 In this case we have a species with an associated site index value but no age/height pair.
-				 * Based on e-mails and conversations with Cam today, we need to consider and perform the following: -
-				 * The underlying models require an age (but not height) - The BHAge will be assumed to be 1.0 (*Peter
-				 * Minter Note: this is Age at Breast Height) - Total Age will be determined from this.
+				 * Mimic WinVDYP value estimation for Model Parameters 2004/03/17 In this case we have a species with an
+				 * associated site index value but no age/height pair. Based on e-mails and conversations with Cam
+				 * today, we need to consider and perform the following: - The underlying models require an age (but not
+				 * height) - The BHAge will be assumed to be 1.0 - Total Age will be determined from this.
 				 */
 				keepTrying = true;
 				ageAtBreastHeight = 1.0;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Vdyp7Constants.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Vdyp7Constants.java
@@ -11,6 +11,7 @@ public class Vdyp7Constants {
 	public static final double EMPTY_DECIMAL = -9.0f;
 	public static final String EMPTY_DECIMAL_TEXT = Double.toString(EMPTY_DECIMAL);
 	public static final int EMPTY_INT = -9;
+	public static final short EMPTY_SHORT = -9;
 	public static final String EMPTY_INT_TEXT = Integer.toString(EMPTY_INT);
 
 	// Polygon related constants

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/NullMath.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/NullMath.java
@@ -1,11 +1,11 @@
 package ca.bc.gov.nrs.vdyp.ecore.utils;
 
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.BinaryOperator;
 
 public class NullMath {
 
-	public static <T extends Number> boolean op(T a, T b, BiFunction<T, T, Boolean> f, T valueIfNull) {
+	public static <T extends Number & Comparable<T>> boolean op(T a, T b, BiPredicate<T, T> f, T valueIfNull) {
 		if (a == null) {
 			a = valueIfNull;
 		}
@@ -13,7 +13,7 @@ public class NullMath {
 			b = valueIfNull;
 		}
 
-		return f.apply(a, b);
+		return f.test(a, b);
 	}
 
 	public static <T extends Number> T max(T a, T b, BinaryOperator<T> maxf, T valueIfNull) {

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/HcsvSingleLayerMultipleSp0sRuntimeStructureTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/HcsvSingleLayerMultipleSp0sRuntimeStructureTest.java
@@ -112,7 +112,7 @@ class HcsvSingleLayerMultipleSp0sRuntimeStructureTest {
 		assertEquals(1, stand0.getSpeciesByPercent().size());
 		Species sp64_0_0 = stand0.getSpeciesByPercent().get(0);
 		assertEquals(stand0, sp64_0_0.getStand());
-		assertTrue(10.4 == sp64_0_0.getAgeAtBreastHeight());
+		assertTrue(80.1 == sp64_0_0.getAgeAtBreastHeight());
 		assertTrue(21.0 == sp64_0_0.getDominantHeight());
 		assertTrue(0 == sp64_0_0.getNDuplicates());
 		assertTrue(1 == sp64_0_0.getPercentsPerDuplicate().size());
@@ -129,7 +129,7 @@ class HcsvSingleLayerMultipleSp0sRuntimeStructureTest {
 
 		Species sp0_0 = stand0.getSpeciesGroup();
 		assertEquals(stand0, sp0_0.getStand());
-		assertTrue(10.4 == sp0_0.getAgeAtBreastHeight());
+		assertTrue(80.1 == sp0_0.getAgeAtBreastHeight());
 		assertTrue(21.0 == sp0_0.getDominantHeight());
 		assertTrue(0 == sp0_0.getNDuplicates());
 		assertTrue(1 == sp0_0.getPercentsPerDuplicate().size());

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/HcsvSingleLayerSingleSp0sMultipleSp64sRuntimeStructureTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/HcsvSingleLayerSingleSp0sMultipleSp64sRuntimeStructureTest.java
@@ -112,7 +112,7 @@ class HcsvSingleLayerSingleSp0sMultipleSp64sRuntimeStructureTest {
 
 		Species sp0_0 = stand0.getSpeciesGroup();
 		assertEquals(stand0, sp0_0.getStand());
-		assertTrue(10.4 == sp0_0.getAgeAtBreastHeight());
+		assertTrue(80.1 == sp0_0.getAgeAtBreastHeight());
 		assertTrue(21.0 == sp0_0.getDominantHeight());
 		assertTrue(0 == sp0_0.getNDuplicates());
 		assertTrue(1 == sp0_0.getPercentsPerDuplicate().size());
@@ -130,7 +130,7 @@ class HcsvSingleLayerSingleSp0sMultipleSp64sRuntimeStructureTest {
 		assertEquals(2, stand0.getSpeciesByPercent().size());
 		Species sp64_0_0 = stand0.getSpeciesByPercent().get(0);
 		assertEquals(stand0, sp64_0_0.getStand());
-		assertTrue(10.4 == sp64_0_0.getAgeAtBreastHeight());
+		assertTrue(80.1 == sp64_0_0.getAgeAtBreastHeight());
 		assertTrue(21.0 == sp64_0_0.getDominantHeight());
 		assertTrue(0 == sp64_0_0.getNDuplicates());
 		assertTrue(1 == sp64_0_0.getPercentsPerDuplicate().size());

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/LayerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/LayerTest.java
@@ -312,8 +312,8 @@ public class LayerTest {
 		}
 
 		@Test
-		void testSuppliedLeadingVeteranLayer() throws PolygonValidationException {
-			layer = buildLayer(Map.of("doSuppressPerHAYields", true, "crownClosure", (short) 10));
+		void testNotSuppliedLeadingVeteranLayer() throws PolygonValidationException {
+			layer = buildLayer(Map.of("doSuppressPerHAYields", true));
 			Map<String, Object> params = Map.of("sp64", "PL", "perc", 100.0, "age", 30.0, "h", 9.0);
 
 			Stand stand = addStand(layer, "PL");

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/LayerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/LayerTest.java
@@ -192,7 +192,7 @@ public class LayerTest {
 			Species sp64 = addSpecies(layer, stand, params);
 
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.calculateEstimatedSiteIndex(context, GrowthModelCode.VRI, false);
 
 			assertNotNull(sp64.getSiteIndex());
@@ -247,7 +247,7 @@ public class LayerTest {
 			}
 
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.calculateEstimatedSiteIndex(context, (GrowthModelCode) layerParams.get("growthModelCode"), false);
 
 			assertNotNull(sp64.getSiteIndex());
@@ -267,7 +267,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 
 			layer.estimateCrownClosure(context);
 
@@ -286,10 +286,10 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.estimateCrownClosure(context);
 
-			// Projections not allowed no leading species
+			// Projections not allowed with no leading species
 			assertThat(polygon.doAllowProjectionOfType(layer.getAssignedProjectionType()), is(false));
 
 		}
@@ -304,7 +304,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.estimateCrownClosure(context);
 
 			// Could not calculate crown closure
@@ -321,7 +321,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			polygon.setLayerByProjectionType(ProjectionTypeCode.VETERAN, layer);
 			layer.estimateCrownClosure(context);
 
@@ -339,7 +339,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.estimateCrownClosure(context);
 
 			// Make sure estimate was pulled from the default for the species
@@ -365,7 +365,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			polygon.setPrimaryLayer(layer);
 			polygon.setLayerByProjectionType(ProjectionTypeCode.PRIMARY, layer);
 			layer.estimateCrownClosure(context);
@@ -393,7 +393,7 @@ public class LayerTest {
 
 			layer.doCompleteDefinition();
 			layer.doBuildSiteSpecies();
-			layer.doCompleteSiteSpeciesSiteIndexInfo();
+			layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 			layer.estimateCrownClosure(context);
 
 			// Make sure estimate was pulled from the default for the species
@@ -473,7 +473,7 @@ public class LayerTest {
 
 		layer.doCompleteDefinition();
 		layer.doBuildSiteSpecies();
-		layer.doCompleteSiteSpeciesSiteIndexInfo();
+		layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 
 		age = layer.determineLayerAgeAtYear(2499);
 		assertThat(age, is(2599.0));// Should reference year oin polygon default to null instead of 0?
@@ -486,7 +486,7 @@ public class LayerTest {
 
 		layer.doCompleteDefinition();
 		layer.doBuildSiteSpecies();
-		layer.doCompleteSiteSpeciesSiteIndexInfo();
+		layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 		age = layer.determineLayerAgeAtYear(2499);
 		assertThat(age, is(579.0));
 
@@ -508,7 +508,7 @@ public class LayerTest {
 		addSpecies(layer, stand, params3);
 
 		layer.doBuildSiteSpecies();
-		layer.doCompleteSiteSpeciesSiteIndexInfo();
+		layer.doCompleteSiteSpeciesSiteIndexInfo(context);
 
 		assertThat(sp64.getTotalAge(), is(100.0));
 	}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/PolygonTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/PolygonTest.java
@@ -175,7 +175,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(null);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);
@@ -222,7 +222,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(null);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);
@@ -269,7 +269,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(null);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);
@@ -316,7 +316,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(null);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);
@@ -363,7 +363,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(null);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);
@@ -512,7 +512,7 @@ public class PolygonTest {
 			stand.addSpeciesGroup(sp0, layer.getSp0sAsSupplied().size());
 			layer.addStand(stand);
 
-			sp64.calculateUndefinedFieldValues();
+			sp64.calculateUndefinedFieldValues(context);
 
 			stand.addSp64(sp64);
 			layer.addSp64(sp64);

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
@@ -17,6 +17,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexEquation;
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestException;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.enumerations.InventoryStandard;
 
 class SpeciesTest {
@@ -291,6 +295,22 @@ class SpeciesTest {
 			} else {
 				assertThat(unit.getDominantHeight(), closeTo(expected, ERROR_TOLERANCE));
 			}
+		}
+
+		@Test
+		void testAggressiveAgeCalculation() throws AbstractProjectionRequestException {
+			var unit = baseConfig(new Species.Builder()).dominantHeight(null).totalAge(null).siteIndex(16.3).build();
+
+			var context = new ProjectionContext(
+					ProjectionRequestKind.HCSV, "TEST",
+					new Parameters().ageStart(0).ageEnd(100).addSelectedExecutionOptionsItem(
+							Parameters.ExecutionOption.ALLOW_AGGRESSIVE_VALUE_ESTIMATION
+					), false
+			);
+			unit.calculateUndefinedFieldValues(context);
+			assertThat(unit.getTotalAge(), is(7.0));
+
+			assertThat(unit.getDominantHeight(), closeTo(1.36, 0.01));
 		}
 
 		@ParameterizedTest

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
@@ -144,7 +144,7 @@ class SpeciesTest {
 					.dominantHeight(Vdyp7Constants.EMPTY_DECIMAL).totalAge(Vdyp7Constants.EMPTY_DECIMAL)
 					.yearsToBreastHeight(Vdyp7Constants.EMPTY_DECIMAL).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getSiteIndex(), is((Double) null));
 			assertThat(unit.getDominantHeight(), is((Double) null));
@@ -153,7 +153,7 @@ class SpeciesTest {
 
 			unit.setSiteCurve(SiteIndexEquation.SI_ACB_HUANG);
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getSiteIndex(), is((Double) null));
 			assertThat(unit.getDominantHeight(), is((Double) null));
@@ -166,7 +166,7 @@ class SpeciesTest {
 		void testMinimalTotalAgeCalculation() {
 			var unit = baseConfig(new Species.Builder()).ageAtBreastHeight(42.0).yearsToBreastHeight(42.0).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getTotalAge(), is(83.5));
 
@@ -176,7 +176,7 @@ class SpeciesTest {
 		void testMinimalYearsToBreastHeight() {
 			var unit = baseConfig(new Species.Builder()).totalAge(42.0).yearsToBreastHeight(21.0).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getTotalAge(), is(42.0));
 
@@ -204,7 +204,7 @@ class SpeciesTest {
 			var unit = baseConfig(new Species.Builder()).stand(stand).totalAge(totalAge)
 					.yearsToBreastHeight(yearsToBreastHeight).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getYearsToBreastHeight(), is(expectedValue));
 		}
@@ -225,7 +225,7 @@ class SpeciesTest {
 			var unit = baseConfig(new Species.Builder()).totalAge(totalAge).dominantHeight(dominantHeight)
 					.siteIndex(null).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			assertThat(unit.getSiteIndex(), is(expectedSiteIndex));
 			if (expectedSiteIndex == null) {
@@ -254,7 +254,7 @@ class SpeciesTest {
 			var unit = baseConfig(new Species.Builder()).totalAge(null).yearsToBreastHeight(yearsToBreastHeight)
 					.dominantHeight(dominantHeight).siteIndex(siteIndex).siteCurve(siteCurve).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			if (expected == null) {
 				assertThat(unit.getTotalAge(), is(expected));
@@ -282,7 +282,7 @@ class SpeciesTest {
 			var unit = baseConfig(new Species.Builder()).dominantHeight(null).yearsToBreastHeight(yearsToBreastHeight)
 					.totalAge(age).siteIndex(siteIndex).siteCurve(siteCurve).build();
 
-			unit.calculateUndefinedFieldValues();
+			unit.calculateUndefinedFieldValues(null);
 
 			if (expected == 0.01) {
 				// dominant height is set nominally on failure


### PR DESCRIPTION
Allow values that were not sent by the Input Model Parameters that were precalculated in WinVDYP to be calculated by the server.

The two instances of this are a crown closure being estimated as the default for the leading species in the event this case is only circumventing the dominant Height check the backend would normally do in that case as WinVDYP would have simply sent the default so the engine could work

The other case is a bit more odd. In the event that no age or height data is sent WnVDYP would assume an age at breast height of 1 use the Supplied SI and Site curve to get a Years to Breast Height value and use that to fill in the Age triplet of age, years to breast height and age at breast height. Then that age would be used for calculating dominant height.  The logic is also only being allowed if the execution option allow aggressive estimation is set