### PR TITLE
Feature/vdyp 668 - Update VRIStart to handle values similar to WinVDYP7 Supplied SI values

### DIFF
--- a/lib/vdyp-common/src/main/java/ca/bc/gov/nrs/vdyp/model/BaseVdypLayer.java
+++ b/lib/vdyp-common/src/main/java/ca/bc/gov/nrs/vdyp/model/BaseVdypLayer.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -70,6 +71,19 @@ public abstract class BaseVdypLayer<S extends BaseVdypSpecies<I>, I extends Base
 	public LinkedHashMap<String, I> getSites() {
 		var result = new LinkedHashMap<String, I>(speciesBySp0.size());
 		speciesBySp0.forEach((key, spec) -> spec.getSite().ifPresent(site -> result.put(key, site)));
+		return result;
+	}
+
+	public List<I> getPriorityOrderedSites() {
+		var result = new LinkedList<I>();
+		Optional<I> primarySite = getPrimarySite();
+		for (var siteEntry : speciesByIndex.values()) {
+			I check = siteEntry.getSite().orElse(null);
+			if (!Objects.equals(primarySite.orElse(null), check)) {
+				result.addLast(check);
+			}
+		}
+		primarySite.ifPresent(result::addFirst);
 		return result;
 	}
 

--- a/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/model/VdypLayerTest.java
+++ b/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/model/VdypLayerTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
@@ -109,10 +110,13 @@ class VdypLayerTest {
 		});
 
 		List<VdypSite> sites = result.getPriorityOrderedSites();
-		assertThat(sites.size(), is(3));
-		assertThat(sites.get(0).getSiteGenus(), is("PL"));
-		assertThat(sites.get(1).getSiteGenus(), is("AC"));
-		assertThat(sites.get(2).getSiteGenus(), is("B"));
+		assertThat(
+				sites, contains(
+						hasProperty("siteGenus", is("PL")), //
+						hasProperty("siteGenus", is("AC")), //
+						hasProperty("siteGenus", is("B"))
+				)
+		);
 	}
 
 	@Test

--- a/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/model/VdypLayerTest.java
+++ b/lib/vdyp-common/src/test/java/ca/bc/gov/nrs/vdyp/model/VdypLayerTest.java
@@ -1,8 +1,15 @@
 package ca.bc.gov.nrs.vdyp.model;
 
-import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.*;
+import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.isPolyId;
+import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.present;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -50,6 +57,62 @@ class VdypLayerTest {
 		assertThat(result, hasProperty("yearsToBreastHeight", present(is(2f))));
 		assertThat(result, hasProperty("height", present(is(10f))));
 		assertThat(result, hasProperty("species", aMapWithSize(1)));
+	}
+
+	@Test
+	void testGetPriorityOrderedSites() {
+		var result = VdypLayer.build(builder -> {
+			builder.polygonIdentifier("Test", 2024);
+			builder.layerType(LayerType.PRIMARY);
+
+			builder.primaryGenus("PL");
+
+			builder.addSpecies(specBuilder -> {
+				specBuilder.genus("AC", 1);
+				specBuilder.percentGenus(45);
+				specBuilder.volumeGroup(-1);
+				specBuilder.decayGroup(-1);
+				specBuilder.breakageGroup(-1);
+				specBuilder.addSite(siteBuilder -> {
+					siteBuilder.height(10f);
+					siteBuilder.ageTotal(42f);
+					siteBuilder.yearsToBreastHeight(2f);
+					siteBuilder.siteCurveNumber(0);
+				});
+			});
+			builder.addSpecies(specBuilder -> {
+				specBuilder.genus("PL", 12);
+				specBuilder.percentGenus(45);
+				specBuilder.volumeGroup(-1);
+				specBuilder.decayGroup(-1);
+				specBuilder.breakageGroup(-1);
+				specBuilder.addSite(siteBuilder -> {
+					siteBuilder.height(10f);
+					siteBuilder.ageTotal(42f);
+					siteBuilder.yearsToBreastHeight(2f);
+					siteBuilder.siteCurveNumber(0);
+				});
+			});
+			builder.addSpecies(specBuilder -> {
+				specBuilder.genus("B", 8);
+				specBuilder.percentGenus(10);
+				specBuilder.volumeGroup(-1);
+				specBuilder.decayGroup(-1);
+				specBuilder.breakageGroup(-1);
+				specBuilder.addSite(siteBuilder -> {
+					siteBuilder.height(10f);
+					siteBuilder.ageTotal(42f);
+					siteBuilder.yearsToBreastHeight(2f);
+					siteBuilder.siteCurveNumber(0);
+				});
+			});
+		});
+
+		List<VdypSite> sites = result.getPriorityOrderedSites();
+		assertThat(sites.size(), is(3));
+		assertThat(sites.get(0).getSiteGenus(), is("PL"));
+		assertThat(sites.get(1).getSiteGenus(), is("AC"));
+		assertThat(sites.get(2).getSiteGenus(), is("B"));
 	}
 
 	@Test

--- a/lib/vdyp-vri/src/main/java/ca/bc/gov/nrs/vdyp/vri/model/VriLayer.java
+++ b/lib/vdyp-vri/src/main/java/ca/bc/gov/nrs/vdyp/vri/model/VriLayer.java
@@ -20,7 +20,7 @@ public class VriLayer extends BaseVdypLayer<VriSpecies, VriSite> implements Inpu
 	private final Optional<Float> baseArea; // VRIL/BAL
 	private final Optional<Float> treesPerHectare; // VRIL/TPHL
 	private final float utilization; // VRIL/UTLL
-	public final Optional<String> primaryGenus; // FIPL_1C/JPRIME_L1 ISPP
+	protected Optional<String> primaryGenus; // FIPL_1C/JPRIME_L1 ISPP
 	private final Optional<String> secondaryGenus; // FIPL_1C/JPRIME_L1 ISPS
 	private final Optional<Integer> empiricalRelationshipParameterIndex; // INXL1/GRPBA1
 	private final float ageIncrease; // YOUNG1/AGE_INCR
@@ -56,6 +56,10 @@ public class VriLayer extends BaseVdypLayer<VriSpecies, VriSite> implements Inpu
 
 	public float getUtilization() {
 		return utilization;
+	}
+
+	public void setPrimaryGenusForCalculation(Optional<String> primaryGenus) {
+		this.primaryGenus = primaryGenus;
 	}
 
 	@Override

--- a/lib/vdyp-vri/src/test/java/ca/bc/gov/nrs/vdyp/vri/VriInputValidationTest.java
+++ b/lib/vdyp-vri/src/test/java/ca/bc/gov/nrs/vdyp/vri/VriInputValidationTest.java
@@ -1,9 +1,13 @@
 package ca.bc.gov.nrs.vdyp.vri;
 
-import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.*;
+import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.notPresent;
+import static ca.bc.gov.nrs.vdyp.test.VdypMatchers.present;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -374,11 +378,11 @@ class VriInputValidationTest {
 					sBuilder.percentGenus(30f);
 					sBuilder.addSp64Distribution("CW", 100);
 					sBuilder.addSite(iBuilder -> {
-						iBuilder.ageTotal(200);
+						// iBuilder.ageTotal(200);
 						iBuilder.height(28.0f);
 						iBuilder.siteIndex(14.3f);
 						iBuilder.siteSpecies("CW");
-						iBuilder.yearsToBreastHeight(10.9f);
+						// iBuilder.yearsToBreastHeight(10.9f);
 						iBuilder.breastHeightAge(189.1f);
 						iBuilder.siteCurveNumber(11);
 					});
@@ -718,7 +722,7 @@ class VriInputValidationTest {
 					sBuilder.addSp64Distribution("CW", 100);
 					sBuilder.addSite(iBuilder -> {
 						iBuilder.ageTotal(200);
-						iBuilder.height(28.0f);
+						// iBuilder.height(28.0f);
 						iBuilder.siteIndex(14.3f);
 						iBuilder.siteSpecies("CW");
 						iBuilder.yearsToBreastHeight(10.9f);


### PR DESCRIPTION
Updated VDYP8 to match VRIStart behavior to match VDYP7 VRIStart to check ALL species for the required values instead of just the primary species. 

In VDYP7 these values are set as the Layer age and height for the sake of the remaining VRI calculations.

In VDYP8 I am assigning PrimaryGenus (which had previously been final) which seems to accomplish the same behavior.

Similar minimal csv values put into VDYP7 are matching VDYP8 values to a tee