### PR TITLE
Feature/VDYP-678: Version and Build number should be displayed in app UI

### DIFF
--- a/.github/workflows/openshift-dev.yml
+++ b/.github/workflows/openshift-dev.yml
@@ -39,7 +39,15 @@ jobs:
     steps:
       - name: Get PR Data
         id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1    
+        uses: bcgov-nr/action-get-pr@v0.0.1
+
+      - name: Inject and Verify GitHub Build Number
+        if: matrix.package == 'frontend'
+        run: |
+          echo "export const BUILD_NUMBER = '${{ github.run_number }}';" > frontend/src/constants/buildNumber.ts
+          echo "Build number injected: ${{ github.run_number }}"
+          echo "Contents of buildNumber.ts:"
+          cat frontend/src/constants/buildNumber.ts
 
       - name: Build and Tag Packages with pr number
         uses: bcgov-nr/action-builder-ghcr@v2.2.0

--- a/.github/workflows/openshift-dev.yml
+++ b/.github/workflows/openshift-dev.yml
@@ -41,14 +41,6 @@ jobs:
         id: pr
         uses: bcgov-nr/action-get-pr@v0.0.1
 
-      - name: Inject and Verify GitHub Build Number
-        if: matrix.package == 'frontend'
-        run: |
-          echo "export const BUILD_NUMBER = '${{ github.run_number }}';" > frontend/src/constants/buildNumber.ts
-          echo "Build number injected: ${{ github.run_number }}"
-          echo "Contents of buildNumber.ts:"
-          cat frontend/src/constants/buildNumber.ts
-
       - name: Build and Tag Packages with pr number
         uses: bcgov-nr/action-builder-ghcr@v2.2.0
         with:
@@ -60,6 +52,7 @@ jobs:
           #triggers: ('${{ matrix.package }}/')
           build_context: .
           build_file: ./${{ matrix.package}}/Dockerfile
+          build_args: BUILD_NUMBER=${{ github.run_number }}
 
       - if: github.event_name == 'push'
         name: Login to GitHub Container Registry

--- a/.github/workflows/openshift-dev.yml
+++ b/.github/workflows/openshift-dev.yml
@@ -37,6 +37,22 @@ jobs:
         package: [backend, frontend]
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK for Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Extract project app version from pom.xml
+        id: get_app_version
+        run: |
+          APP_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Extracted APP_VERSION: $APP_VERSION"
+          echo "::set-output name=APP_VERSION::$APP_VERSION"
+
       - name: Get PR Data
         id: pr
         uses: bcgov-nr/action-get-pr@v0.0.1
@@ -52,7 +68,9 @@ jobs:
           #triggers: ('${{ matrix.package }}/')
           build_context: .
           build_file: ./${{ matrix.package}}/Dockerfile
-          build_args: BUILD_NUMBER=${{ github.run_number }}
+          build_args: |
+            BUILD_NUMBER=${{ github.run_number }}
+            APP_VERSION=${{ steps.get_app_version.outputs.APP_VERSION }}
 
       - if: github.event_name == 'push'
         name: Login to GitHub Container Registry

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "export const BUILD_NUMBER = '${BUILD_NUMBER}'" > src/constants/buildNu
     npm run build-only
 
 # Deploy using Caddy to host static files
-FROM caddy:2.8.4-alpine
+FROM caddy:2.10.0-alpine
 
 # Install packages and ensure permissions in one RUN command
 RUN apk add --no-cache ca-certificates && \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,9 +29,8 @@ RUN update-ca-certificates
 ARG CONTEXT="./frontend"
 COPY --from=build /app/dist /srv
 COPY ${CONTEXT}/Caddyfile /etc/caddy/Caddyfile
-RUN caddy fmt --overwrite /etc/caddy/Caddyfile
-
-RUN chmod 755 /usr/bin/caddy
+RUN caddy fmt --overwrite /etc/caddy/Caddyfile && \
+    chmod 755 /usr/bin/caddy
 
 # Ports, health check and non-root user
 EXPOSE 3000 3001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,12 +2,14 @@
 # Node Bullseye has npm
 FROM node:22.17.0-bullseye-slim AS build
 ARG CONTEXT="./frontend"
+ARG BUILD_NUMBER
 # Install packages, build and keep only prod packages
 WORKDIR /app
 COPY ${CONTEXT}/*.json ${CONTEXT}/*.ts ${CONTEXT}/index.html ./
 COPY ${CONTEXT}/public ./public
 COPY ${CONTEXT}/src ./src
-RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
+RUN echo "export const BUILD_NUMBER = '${BUILD_NUMBER}'" > src/constants/buildNumber.ts && \
+    npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build-only
 
 # Deploy using Caddy to host static files

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,12 +3,14 @@
 FROM node:22.17.0-bullseye-slim AS build
 ARG CONTEXT="./frontend"
 ARG BUILD_NUMBER
+ARG APP_VERSION
 # Install packages, build and keep only prod packages
 WORKDIR /app
 COPY ${CONTEXT}/*.json ${CONTEXT}/*.ts ${CONTEXT}/index.html ./
 COPY ${CONTEXT}/public ./public
 COPY ${CONTEXT}/src ./src
 RUN echo "export const BUILD_NUMBER = '${BUILD_NUMBER}'" > src/constants/buildNumber.ts && \
+    echo "export const APP_VERSION = '${APP_VERSION}'" > src/constants/appVersion.ts && \
     npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build-only
 

--- a/frontend/cypress/support/component-index.html
+++ b/frontend/cypress/support/component-index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <title>Components App</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vdyp",
-  "version": "0.0.1.120",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vdyp",
-      "version": "0.0.1.120",
+      "version": "8.0.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@bcgov/bc-sans": "2.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,6 @@
         "pinia": "3.0.3",
         "print-js": "1.6.0",
         "vdyp": "file:",
-        "vite-plugin-package-version": "1.1.0",
         "vue": "3.5.17",
         "vue-router": "4.5.1",
         "vuetify": "3.8.11"
@@ -8582,15 +8581,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-package-version": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-package-version/-/vite-plugin-package-version-1.1.0.tgz",
-      "integrity": "sha512-TPoFZXNanzcaKCIrC3e2L/TVRkkRLB6l4RPN/S7KbG7rWfyLcCEGsnXvxn6qR7fyZwXalnnSN/I9d6pSFjHpEA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": ">=2.0.0-beta.69"
       }
     },
     "node_modules/vite-plugin-vuetify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vdyp",
-  "version": "0.0.1.120",
+  "version": "8.0.0",
   "private": true,
   "type": "module",
   "description": "Variable Density Yield Projection",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "pinia": "3.0.3",
     "print-js": "1.6.0",
     "vdyp": "file:",
-    "vite-plugin-package-version": "1.1.0",
     "vue": "3.5.17",
     "vue-router": "4.5.1",
     "vuetify": "3.8.11"

--- a/frontend/src/components/common/AppMessageDialog.cy.ts
+++ b/frontend/src/components/common/AppMessageDialog.cy.ts
@@ -27,6 +27,7 @@ describe('<AppMessageDialog />', () => {
     message: MDL_PRM_INPUT_ERR.SPCZ_VLD_TOTAL_PCT,
     dialogWidth: 400,
     btnLabel: BUTTON_LABEL.CONT_EDIT,
+    scrollStrategy: 'none',
   }
 
   it('renders with default props', () => {
@@ -120,22 +121,5 @@ describe('<AppMessageDialog />', () => {
 
     // Check if the dialog is not exist
     cy.get('.v-dialog').should('not.exist')
-  })
-
-  it('renders with default props', () => {
-    cy.mount(AppMessageDialog, { props: defaultProps })
-
-    cy.get('.v-dialog').should('be.visible')
-
-    cy.get('.v-overlay__content').should(
-      'have.css',
-      'justify-content',
-      'center',
-    )
-    cy.get('.v-overlay__content').should('have.css', 'align-items', 'center')
-
-    cy.get('.popup-header').should('contain', defaultProps.title)
-    cy.get('.v-card-text').should('contain', defaultProps.message)
-    cy.get('button').should('contain', defaultProps.btnLabel)
   })
 })

--- a/frontend/src/components/common/AppMessageDialog.vue
+++ b/frontend/src/components/common/AppMessageDialog.vue
@@ -4,6 +4,7 @@
     @update:model-value="updateDialog"
     persistent
     :max-width="computedDialogWidth"
+    :scroll-strategy="computedScrollStrategy"
   >
     <v-card :style="computedDialogStyle">
       <v-card-title :style="computedHeaderStyle" class="popup-header">
@@ -54,6 +55,7 @@ const props = defineProps<{
   headerBackground?: string
   headerColor?: string
   actionsBackground?: string
+  scrollStrategy?: any
 }>()
 
 const emit = defineEmits(['update:dialog', 'close'])
@@ -82,6 +84,10 @@ const computedDialogStyle = computed(() => {
   return {
     borderRadius: `${props.dialogBorderRadius ?? 8}px`,
   }
+})
+
+const computedScrollStrategy = computed(() => {
+  return props.scrollStrategy ?? 'block'
 })
 
 // Emit updates for dialog visibility

--- a/frontend/src/constants/appVersion.ts
+++ b/frontend/src/constants/appVersion.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = 'DEV'

--- a/frontend/src/constants/buildNumber.ts
+++ b/frontend/src/constants/buildNumber.ts
@@ -1,0 +1,1 @@
+export const BUILD_NUMBER = 'DEV'

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-navigation-drawer app v-model="drawer" permanent>
+  <v-navigation-drawer app v-model="drawer" :rail="isRail" permanent>
     <v-list density="compact" class="nv-project-menu">
       <router-link to="/" class="link-no-decoration">
         <v-list-item
           link
-          prepend-icon="mdi-clipboard-text"
+          prepend-icon="mdi-folder"
           class="nv-menu-item"
           value="projects"
         >
@@ -12,9 +12,55 @@
         </v-list-item>
       </router-link>
     </v-list>
-
     <div class="nv-drawer-footer">
-      <span class="ml-2 app-build-release">Release: {{ appVersion }}</span>
+      <!-- on collapsed navi -->
+      <div v-if="isRail">
+        <div
+          class="collapsed-build-release-area"
+          @click="toggleVersion"
+          style="cursor: pointer"
+        >
+          {{ showVersion ? `v${appVersion}` : `#${buildNumber}` }}
+        </div>
+        <v-tooltip
+          :text="isRail ? 'Expand sidebar' : 'Collapse sidebar'"
+          location="right"
+        >
+          <template v-slot:activator="{ props }">
+            <v-icon
+              v-bind="props"
+              @click="toggleRail"
+              class="collapsed-icon-area"
+              style="color: #000000"
+              icon="mdi-arrow-collapse-right"
+            />
+          </template>
+        </v-tooltip>
+      </div>
+      <!-- on expanded navi -->
+      <div v-else class="expanded-footer">
+        <span
+          class="expanded-build-release-area"
+          @click="toggleVersion"
+          style="cursor: pointer"
+        >
+          {{ showVersion ? `Version: ${appVersion}` : `Build: ${buildNumber}` }}
+        </span>
+        <v-tooltip
+          :text="isRail ? 'Expand sidebar' : 'Collapse sidebar'"
+          location="right"
+        >
+          <template v-slot:activator="{ props }">
+            <v-icon
+              v-bind="props"
+              @click="toggleRail"
+              class="expanded-icon-area"
+              style="color: #000000"
+              icon="mdi-arrow-collapse-left"
+            />
+          </template>
+        </v-tooltip>
+      </div>
     </div>
   </v-navigation-drawer>
 
@@ -25,9 +71,20 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { BUILD_NUMBER } from '@/constants/buildNumber'
 
 const appVersion = import.meta.env.PACKAGE_VERSION
 const drawer = ref(true)
+const showVersion = ref(true)
+const isRail = ref(false)
+const buildNumber = BUILD_NUMBER
+
+const toggleRail = () => {
+  isRail.value = !isRail.value
+}
+const toggleVersion = () => {
+  showVersion.value = !showVersion.value
+}
 </script>
 
 <style scoped>
@@ -68,9 +125,72 @@ const drawer = ref(true)
   position: absolute;
   bottom: 0;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.app-build-release {
-  color: #f6f6f6;
+.v-navigation-drawer--rail .nv-menu-item-title {
+  display: none;
+}
+
+.v-navigation-drawer--rail .nv-menu-item {
+  padding: 0 0 0 48px;
+  justify-content: center;
+  width: 100%;
+}
+
+.collapsed-build-release-area {
+  margin-bottom: 4px;
+  padding: 5px;
+}
+
+.collapsed-build-release-area:hover {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  padding: 5px;
+}
+
+.collapsed-icon-area {
+  cursor: pointer;
+  justify-content: center;
+  padding: 20px;
+}
+
+.collapsed-icon-area:hover {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  padding: 20px;
+}
+
+.expanded-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+}
+
+.expanded-build-release-area {
+  padding: 5px 10px 5px 10px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.expanded-build-release-area:hover {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+}
+
+.expanded-icon-area {
+  cursor: pointer;
+  padding: 20px;
+  margin-right: 10px;
+}
+
+.expanded-icon-area:hover {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  padding: 20px;
+  margin-right: 10px;
 }
 </style>

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -80,16 +80,30 @@
     </div>
   </v-navigation-drawer>
 
-  <div class="main-layout-container">
+  <div
+    :style="{ marginLeft: isRail ? '24px' : '0' }"
+    class="main-layout-container"
+  >
     <slot />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { APP_VERSION } from '@/constants/appVersion'
 import { BUILD_NUMBER } from '@/constants/buildNumber'
 
-const appVersion = import.meta.env.PACKAGE_VERSION
+const appVersion = computed(() => {
+  if (APP_VERSION) {
+    const baseVersion = APP_VERSION.replace(
+      /(-snapshot|-SNAPSHOT|-Snapshot)/i,
+      '',
+    )
+    return `${baseVersion}.${BUILD_NUMBER || ''}`
+  }
+  return ''
+})
+
 const drawer = ref(true)
 const showVersion = ref(true)
 const isRail = ref(false)
@@ -144,6 +158,10 @@ const toggleVersion = () => {
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.v-navigation-drawer--rail {
+  width: 80px !important;
 }
 
 .v-navigation-drawer--rail .nv-menu-item-title {

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -1,8 +1,23 @@
 <template>
   <v-navigation-drawer app v-model="drawer" :rail="isRail" permanent>
+    <!-- menu -->
     <v-list density="compact" class="nv-project-menu">
       <router-link to="/" class="link-no-decoration">
+        <v-tooltip v-if="isRail" :text="'Projects'" location="right">
+          <template v-slot:activator="{ props }">
+            <v-list-item
+              v-bind="props"
+              link
+              prepend-icon="mdi-folder"
+              class="nv-menu-item"
+              value="projects"
+            >
+              <span class="nv-menu-item-title">Projects</span>
+            </v-list-item>
+          </template>
+        </v-tooltip>
         <v-list-item
+          v-else
           link
           prepend-icon="mdi-folder"
           class="nv-menu-item"
@@ -12,6 +27,7 @@
         </v-list-item>
       </router-link>
     </v-list>
+    <!-- version info -->
     <div class="nv-drawer-footer">
       <!-- on collapsed navi -->
       <div v-if="isRail">

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -32,7 +32,7 @@
               @click="toggleRail"
               class="collapsed-icon-area"
               style="color: #000000"
-              icon="mdi-arrow-collapse-right"
+              icon="mdi-chevron-double-right"
             />
           </template>
         </v-tooltip>
@@ -56,7 +56,7 @@
               @click="toggleRail"
               class="expanded-icon-area"
               style="color: #000000"
-              icon="mdi-arrow-collapse-left"
+              icon="mdi-chevron-double-left"
             />
           </template>
         </v-tooltip>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,6 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig, loadEnv } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import Vuetify from 'vite-plugin-vuetify'
-import packageVersion from 'vite-plugin-package-version'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -28,7 +27,6 @@ export default defineConfig(({ mode }) => {
         },
       },
       Vue(),
-      packageVersion(),
       Vuetify({
         autoImport: true,
       }),


### PR DESCRIPTION
- Display Version and Build number on the sidebar bottom
- Pass the build number as a build argument in the GitHub Actions workflow and directly update the build number information file in the Dockerfile.
- Extract app version from parent pom and pass it to dockerfile to display it as version number on the screen
- Remove the vite-plugin-package-version dependency (used to read the version in package.json), which is no longer needed
- Upgrade caddy to the latest version
- Change to merge consecutive RUN instructions in the dockerfile