### PR TITLE
VDYP-685: version->8.0.0-SNAPSHOT in all pom.xml

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ca.bc.gov.nrs.vdyp</groupId>
     <artifactId>vdyp-root</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>vdyp-backend</artifactId>
   <name>Variable Density Yield Project - Backend</name>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/lib/vdyp-common/pom.xml
+++ b/lib/vdyp-common/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-buildtools</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>8.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/lib/vdyp-extended-core/pom.xml
+++ b/lib/vdyp-extended-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-fip/pom.xml
+++ b/lib/vdyp-fip/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-forward/pom.xml
+++ b/lib/vdyp-forward/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	
 	<dependencies>

--- a/lib/vdyp-integration-tests/pom.xml
+++ b/lib/vdyp-integration-tests/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-si32/pom.xml
+++ b/lib/vdyp-si32/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<build>
@@ -36,13 +36,13 @@
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>8.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-sindex</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>8.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/lib/vdyp-sindex/pom.xml
+++ b/lib/vdyp-sindex/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/lib/vdyp-vri/pom.xml
+++ b/lib/vdyp-vri/pom.xml
@@ -12,14 +12,14 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>8.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
 	<artifactId>vdyp-root</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>8.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Variable Density Yield Project - Parent</name>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
   <artifactId>report-aggregate</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>8.0.0-SNAPSHOT</version>
   <name>Variable Density Yield Project - Report Aggregation</name>
   <description>Aggregate Coverage Report</description>
 

--- a/vdyp-test-oracle/pom.xml
+++ b/vdyp-test-oracle/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
After some internal discussion about VDYP-678, we decided to set the application version in the parent pom and show it as the version number on the screen.

This means that not only the parent pom, but also the versions in the pom.xml of the child modules will need to be upgraded to 8.0.0.