### PR TITLE
Feature/VDYP-687 - Enhance Unit Test Coverage for Functions and Business Logic [2]

### DIFF
--- a/frontend/src/stores/appStore.cy.ts
+++ b/frontend/src/stores/appStore.cy.ts
@@ -1,0 +1,32 @@
+/// <reference types="cypress" />
+
+import { setActivePinia, createPinia } from 'pinia'
+import { useAppStore } from '@/stores/appStore'
+import { DEFAULTS } from '@/constants'
+import * as CONSTANTS from '@/constants/constants'
+
+describe('App Store Unit Tests', () => {
+  let appStore: ReturnType<typeof useAppStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    appStore = useAppStore()
+  })
+
+  it('should initialize with default model selection', () => {
+    expect(appStore.modelSelection).to.equal(
+      DEFAULTS.DEFAULT_VALUES.MODEL_SELECTION,
+    )
+  })
+
+  it('should get the correct model selection', () => {
+    expect(appStore.getModelSelection).to.equal(appStore.modelSelection)
+  })
+
+  it('should set the model selection correctly', () => {
+    const newSelection = CONSTANTS.MODEL_SELECTION.INPUT_MODEL_PARAMETERS
+    appStore.setModelSelection(newSelection)
+    expect(appStore.modelSelection).to.equal(newSelection)
+    expect(appStore.getModelSelection).to.equal(newSelection)
+  })
+})

--- a/frontend/src/stores/common/authStore.cy.ts
+++ b/frontend/src/stores/common/authStore.cy.ts
@@ -74,11 +74,12 @@ describe('Auth Store Unit Tests', () => {
       client_roles: ['admin'],
     })
     const base64Token = btoa(mockToken)
-    authStore.user = {
+    const user = {
       accessToken: '',
       refToken: '',
       idToken: `mock.${base64Token}.token`,
     }
+    authStore.setUser(user)
 
     const parsed = authStore.parseIdToken()
 
@@ -123,11 +124,12 @@ describe('Auth Store Unit Tests', () => {
   })
 
   it('should handle invalid ID tokens', () => {
-    authStore.user = {
+    const user = {
       accessToken: '',
       refToken: '',
       idToken: 'invalid.token',
     }
+    authStore.setUser(user)
 
     cy.spy(console, 'error').as('consoleError')
 
@@ -138,5 +140,74 @@ describe('Auth Store Unit Tests', () => {
       'have.been.calledWithMatch',
       'Invalid ID Token format',
     )
+  })
+
+  it('should not load user if sessionStorage is empty', () => {
+    sessionStorage.removeItem('authUser')
+    authStore.loadUserFromStorage()
+
+    expect(authStore.user).to.be.null
+    expect(authStore.authenticated).to.be.false
+  })
+
+  it('should update user correctly', () => {
+    const initialUser = {
+      accessToken: 'initial_access',
+      refToken: 'initial_refresh',
+      idToken: 'initial_id',
+    }
+    authStore.setUser(initialUser)
+
+    const updatedUser = {
+      accessToken: 'updated_access',
+      refToken: 'updated_refresh',
+      idToken: 'updated_id',
+    }
+    authStore.setUser(updatedUser)
+
+    expect(authStore.user).to.deep.equal(updatedUser)
+    expect(authStore.authenticated).to.be.true
+    cy.wrap(sessionStorage.getItem('authUser')).should(
+      'equal',
+      JSON.stringify(updatedUser),
+    )
+  })
+
+  it('should handle malformed ID tokens', () => {
+    const malformedTokens = [
+      'token.without.dots',
+      'token.with.one.dot',
+      'token.with.three.dots.but.invalid.base64',
+    ]
+
+    cy.spy(console, 'error').as('consoleError')
+
+    malformedTokens.forEach((token) => {
+      const user = {
+        accessToken: '',
+        refToken: '',
+        idToken: token,
+      }
+      authStore.setUser(user)
+      const parsed = authStore.parseIdToken()
+      expect(parsed).to.be.null
+    })
+
+    cy.get('@consoleError').should('have.been.calledThrice')
+  })
+
+  it('should correctly reflect computed properties', () => {
+    expect(authStore.getAuthenticated).to.be.false
+    expect(authStore.getUser).to.be.null
+
+    const user = {
+      accessToken: 'access_token',
+      refToken: 'refresh_token',
+      idToken: 'id_token',
+    }
+    authStore.setUser(user)
+
+    expect(authStore.getAuthenticated).to.be.true
+    expect(authStore.getUser).to.deep.equal(user)
   })
 })

--- a/frontend/src/stores/fileUploadStore.cy.ts
+++ b/frontend/src/stores/fileUploadStore.cy.ts
@@ -138,4 +138,65 @@ describe('FileUploadStore Unit Tests', () => {
     expect(store.polygonFile).to.equal(polygonFile)
     expect(store.layerFile).to.equal(layerFile)
   })
+
+  it('should handle full confirmation flow', () => {
+    // Initial state
+    expect(store.panelOpenStates.reportInfo).to.equal(CONSTANTS.PANEL.OPEN)
+    expect(store.panelState.reportInfo.editable).to.be.true
+    expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
+    expect(store.panelState.attachments.editable).to.be.false
+    expect(store.runModelEnabled).to.be.false
+
+    // Confirm reportInfo
+    store.confirmPanel(CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO)
+    expect(store.panelState.reportInfo.confirmed).to.be.true
+    expect(store.panelState.reportInfo.editable).to.be.false
+    expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
+    expect(store.panelState.attachments.editable).to.be.true
+    expect(store.runModelEnabled).to.be.false
+
+    // Confirm attachments
+    store.confirmPanel(CONSTANTS.FILE_UPLOAD_PANEL.ATTACHMENTS)
+    expect(store.panelState.attachments.confirmed).to.be.true
+    expect(store.panelState.attachments.editable).to.be.false
+    expect(store.runModelEnabled).to.be.true
+  })
+
+  it('should reset subsequent panels when editing a confirmed panel', () => {
+    // Confirm both panels
+    store.confirmPanel(CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO)
+    store.confirmPanel(CONSTANTS.FILE_UPLOAD_PANEL.ATTACHMENTS)
+    expect(store.runModelEnabled).to.be.true
+
+    // Edit reportInfo
+    store.editPanel(CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO)
+    expect(store.panelState.reportInfo.confirmed).to.be.false
+    expect(store.panelState.reportInfo.editable).to.be.true
+    expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
+    expect(store.panelState.attachments.confirmed).to.be.false
+    expect(store.panelState.attachments.editable).to.be.false
+    expect(store.runModelEnabled).to.be.false
+  })
+
+  it('should not enable run model button when not all panels are confirmed', () => {
+    store.confirmPanel(CONSTANTS.FILE_UPLOAD_PANEL.REPORT_INFO)
+    expect(store.runModelEnabled).to.be.false
+  })
+
+  it('should handle setting and unsetting attachment files', () => {
+    const polygonFile = new File(['polygon'], 'polygon.csv', {
+      type: 'text/csv',
+    })
+    const layerFile = new File(['layer'], 'layer.csv', { type: 'text/csv' })
+
+    store.polygonFile = polygonFile
+    store.layerFile = layerFile
+    expect(store.polygonFile).to.equal(polygonFile)
+    expect(store.layerFile).to.equal(layerFile)
+
+    store.polygonFile = null
+    store.layerFile = null
+    expect(store.polygonFile).to.be.null
+    expect(store.layerFile).to.be.null
+  })
 })

--- a/frontend/src/stores/reportingStore.cy.ts
+++ b/frontend/src/stores/reportingStore.cy.ts
@@ -1,0 +1,40 @@
+/// <reference types="cypress" />
+
+import { setActivePinia, createPinia } from 'pinia'
+import { useReportingStore } from '@/stores/reportingStore'
+
+describe('Reporting Store Unit Tests', () => {
+  let reportingStore: ReturnType<typeof useReportingStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    reportingStore = useReportingStore()
+  })
+
+  it('should initialize with default state', () => {
+    expect(reportingStore.modelParamReportingTabsEnabled).to.be.false
+    expect(reportingStore.fileUploadReportingTabsEnabled).to.be.false
+  })
+
+  it('should enable modelParamReportingTabs', () => {
+    reportingStore.modelParamEnableTabs()
+    expect(reportingStore.modelParamReportingTabsEnabled).to.be.true
+  })
+
+  it('should disable modelParamReportingTabs', () => {
+    reportingStore.modelParamEnableTabs() // First enable
+    reportingStore.modelParamDisableTabs()
+    expect(reportingStore.modelParamReportingTabsEnabled).to.be.false
+  })
+
+  it('should enable fileUploadReportingTabs', () => {
+    reportingStore.fileUploadEnableTabs()
+    expect(reportingStore.fileUploadReportingTabsEnabled).to.be.true
+  })
+
+  it('should disable fileUploadReportingTabs', () => {
+    reportingStore.fileUploadEnableTabs() // First enable
+    reportingStore.fileUploadDisableTabs()
+    expect(reportingStore.fileUploadReportingTabsEnabled).to.be.false
+  })
+})


### PR DESCRIPTION
New cypress unit tests and existing unit tests modification for appStore, authStore, fileUploadStore, modelParameterStore, reportingStore 

- Reflect recent function or business logic changes where necessary, and enhance the test suite by adding cases, including more thorough edge case testing, to ensure comprehensive validation and robustness.