### PR TITLE
Feature/VDYP-699,697,696 UAT Feedback

### DIFF
--- a/frontend/src/components/input/ReportConfiguration.cy.ts
+++ b/frontend/src/components/input/ReportConfiguration.cy.ts
@@ -298,10 +298,6 @@ describe('ReportConfiguration.vue', () => {
     cy.get('[data-testid="volume-reported"] input[type="checkbox"]').should(
       'be.disabled',
     )
-
-    cy.contains('.v-input', CONSTANTS.INCLUDE_IN_REPORT.COMPUTED_MAI)
-      .find('input[type="checkbox"]')
-      .should('be.disabled')
   })
 
   it('enables Culmination Values checkbox when Starting Age <= 10 and Finishing Age >= 300', () => {

--- a/frontend/src/components/input/ReportConfiguration.vue
+++ b/frontend/src/components/input/ReportConfiguration.vue
@@ -404,8 +404,6 @@ const isVolumeReportedDisabled = computed(() => {
 const getIncludeInReportDisabled = (value: string) => {
   if (value === CONSTANTS.INCLUDE_IN_REPORT.CULMINATION_VALUES) {
     return !isCulminationValuesEnabled.value
-  } else if (value === CONSTANTS.INCLUDE_IN_REPORT.COMPUTED_MAI) {
-    return localProjectionType.value === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
   }
   return props.isDisabled
 }

--- a/frontend/src/components/input/attachments/AttachmentsPanel.cy.ts
+++ b/frontend/src/components/input/attachments/AttachmentsPanel.cy.ts
@@ -209,43 +209,4 @@ describe('AttachmentsPanel.vue', () => {
 
     cy.contains('polygon.csv').should('not.exist')
   })
-
-  it('enables edit mode when edit button is clicked', () => {
-    mount(AttachmentsPanel, {
-      global: {
-        plugins: [vuetify],
-      },
-    })
-
-    const polygonFile = new File(['polygon content'], 'polygon.csv', {
-      type: 'text/csv',
-    })
-    const layerFile = new File(['layer content'], 'layer.csv', {
-      type: 'text/csv',
-    })
-
-    cy.get('#polygon-file-input').should('exist').selectFile(
-      {
-        contents: polygonFile,
-        fileName: 'polygon.csv',
-        mimeType: 'text/csv',
-      },
-      { force: true },
-    )
-
-    cy.get('#layer-file-input').should('exist').selectFile(
-      {
-        contents: layerFile,
-        fileName: 'layer.csv',
-        mimeType: 'text/csv',
-      },
-      { force: true },
-    )
-
-    cy.get('button').contains('Confirm').click()
-
-    cy.get('button').contains('Edit').click()
-
-    cy.get('.v-file-input').first().should('not.be.disabled')
-  })
 })

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -43,8 +43,8 @@ export const VOLUME_REPORTED = Object.freeze({
 
 export const INCLUDE_IN_REPORT = Object.freeze({
   COMPUTED_MAI: 'Computed MAI',
-  SPECIES_COMPOSITION: 'Species Composition',
   CULMINATION_VALUES: 'Culmination Values',
+  BY_SPECIES: 'By Species',
 })
 
 export const PROJECTION_TYPE = Object.freeze({

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -52,6 +52,8 @@ export const MSG_DIALOG_TITLE = Object.freeze({
   NO_MODIFY: 'No Modifications!',
   MISSING_FILE: 'Missing File',
   INVALID_FILE: 'Invalid File!',
+  POLYGON_FILE_HEADER_MISMATCH: 'Polygon File Header Mismatch!',
+  LAYER_FILE_HEADER_MISMATCH: 'Layer File Header Mismatch!',
 })
 
 export const MDL_PRM_INPUT_HINT = Object.freeze({

--- a/frontend/src/constants/options.ts
+++ b/frontend/src/constants/options.ts
@@ -56,12 +56,12 @@ export const volumeReportedOptions = [
 export const includeInReportOptions = [
   { label: 'Computed MAI', value: CONSTANTS.INCLUDE_IN_REPORT.COMPUTED_MAI },
   {
-    label: 'Species Composition',
-    value: CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
-  },
-  {
     label: 'Culmination Values',
     value: CONSTANTS.INCLUDE_IN_REPORT.CULMINATION_VALUES,
+  },
+  {
+    label: 'By Species',
+    value: CONSTANTS.INCLUDE_IN_REPORT.BY_SPECIES,
   },
 ]
 

--- a/frontend/src/services/fileUploadService.cy.ts
+++ b/frontend/src/services/fileUploadService.cy.ts
@@ -26,9 +26,7 @@ describe('File Upload Service Unit Tests', () => {
     fileUploadStore = useFileUploadStore()
 
     fileUploadStore.projectionType = CONSTANTS.PROJECTION_TYPE.VOLUME
-    fileUploadStore.includeInReport = [
-      CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
-    ]
+    fileUploadStore.includeInReport = [CONSTANTS.INCLUDE_IN_REPORT.BY_SPECIES]
     fileUploadStore.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.AGE
     fileUploadStore.startingAge = 10
     fileUploadStore.finishingAge = 100

--- a/frontend/src/services/fileUploadService.ts
+++ b/frontend/src/services/fileUploadService.ts
@@ -42,7 +42,7 @@ export const getSelectedExecutionOptions = (
   if (
     fileUploadStore.includeInReport &&
     fileUploadStore.includeInReport.includes(
-      CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
+      CONSTANTS.INCLUDE_IN_REPORT.BY_SPECIES,
     )
   ) {
     selectedExecutionOptions.push(

--- a/frontend/src/services/modelParameterService.ts
+++ b/frontend/src/services/modelParameterService.ts
@@ -384,7 +384,7 @@ const buildSelectedExecutionOptions = (
   if (
     modelParameterStore.includeInReport &&
     modelParameterStore.includeInReport.includes(
-      CONSTANTS.INCLUDE_IN_REPORT.SPECIES_COMPOSITION,
+      CONSTANTS.INCLUDE_IN_REPORT.BY_SPECIES,
     )
   ) {
     options.push(SelectedExecutionOptionsEnum.DoIncludeSpeciesProjection)

--- a/frontend/src/validation/fileUploadValidation.ts
+++ b/frontend/src/validation/fileUploadValidation.ts
@@ -93,3 +93,11 @@ export const validateFiles = async (
 
   return { isValid: true }
 }
+
+export const validatePolygonHeader = async (file: File) => {
+  return fileUploadValidator.validatePolygonHeader(file)
+}
+
+export const validateLayerHeader = async (file: File) => {
+  return fileUploadValidator.validateLayerHeader(file)
+}


### PR DESCRIPTION
- VDYP-696: Change order and text for Include in Report parameters / Refactor: Rename 'SPECIES_COMPOSITION' to 'BY_SPECIES' across codebase for consistency
- VDYP-697: When the Report Information section has been confirmed, all fields should be read-only, including the Computed MAI
- VDYP-699: When validating attachments confirm that column names and order are correct in the attached Polygon and Layer files