### PR TITLE
Feature/vdyp 704 - Adding OIDC token parsing to backend

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -141,6 +141,7 @@ jobs:
             --set-string global.repository=${{ github.repository }} \
             --set-string global.tag=${{ steps.vars.outputs.tag }} \
             ${{ inputs.params }} \
+            --set backend.env.QUARKUS_OIDC_AUTH_SERVER_URL=${{ secrets.VITE_SSO_AUTH_SERVER_URL }}/realms/${{ secrets.VITE_SSO_REALM }} \
             --set frontend.env.VITE_SSO_AUTH_SERVER_URL=${{ secrets.VITE_SSO_AUTH_SERVER_URL }} \
             --set frontend.env.VITE_SSO_CLIENT_ID=${{ secrets.VITE_SSO_CLIENT_ID }} \
             --set frontend.env.VITE_SSO_REALM=${{ secrets.VITE_SSO_REALM }} \
@@ -162,6 +163,7 @@ jobs:
             --set-string global.tag=${{ steps.vars.outputs.tag }} \
             ${{ inputs.params }} \
             ${{ steps.vars.outputs.release }} \
+            --set backend.env.QUARKUS_OIDC_AUTH_SERVER_URL=${{ secrets.VITE_SSO_AUTH_SERVER_URL }}/realm/${{ secrets.VITE_SSO_REALM }} \
             --set frontend.env.VITE_SSO_AUTH_SERVER_URL=${{ secrets.VITE_SSO_AUTH_SERVER_URL }} \
             --set frontend.env.VITE_SSO_CLIENT_ID=${{ secrets.VITE_SSO_CLIENT_ID }} \
             --set frontend.env.VITE_SSO_REALM=${{ secrets.VITE_SSO_REALM }} \

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -304,6 +304,10 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-oidc</artifactId>
+		</dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: LOG_LEVEL
               value: info
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
-              value: { { .Values.backend.env.QUARKUS_OIDC_AUTH_SERVER_URL | quote } }
+              value: {{ .Values.backend.env.QUARKUS_OIDC_AUTH_SERVER_URL | quote }}
             - name: QUARKUS_OIDC_APPLICATION_TYPE
               value: "service"
             - name: QUARKUS_OIDC_CREDENTIALS_SECRET

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
           env:
             - name: LOG_LEVEL
               value: info
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: { { .Values.backend.env.QUARKUS_OIDC_AUTH_SERVER_URL | quote } }
+            - name: QUARKUS_OIDC_APPLICATION_TYPE
+              value: "service"
+            - name: QUARKUS_OIDC_CREDENTIALS_SECRET
+              value: ""
           ports:
             - name: http
               containerPort: {{ .Values.backend.service.targetPort }}

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -68,6 +68,8 @@ backend:
   pdb:
     enabled: false # enable it in PRODUCTION for having pod disruption budget.
     minAvailable: 1 # the minimum number of pods that must be available during the disruption budget.
+  env:
+    QUARKUS_OIDC_AUTH_SERVER_URL: ~
 
 frontend:
   fullnameOverride: "vdyp-ui-dev"

--- a/charts/app/values-test.yaml
+++ b/charts/app/values-test.yaml
@@ -68,6 +68,8 @@ backend:
   pdb:
     enabled: false # enable it in PRODUCTION for having pod disruption budget.
     minAvailable: 1 # the minimum number of pods that must be available during the disruption budget.
+  env:
+    QUARKUS_OIDC_AUTH_SERVER_URL: ~
 
 frontend:
   fullnameOverride: "vdyp-ui-test"


### PR DESCRIPTION
Added via Quarkus' built-in oidc package. This should provide Role Based Access Control (RBAC) for any endpoint through simple annotation, and also provides the ability to get claims (Such as roles and name) from the JWT token through a simple Injection.