### PR TITLE
VDYP-743: Enable multiple yield table output

### DIFF
--- a/frontend/src/components/reporting/ReportingContainer.vue
+++ b/frontend/src/components/reporting/ReportingContainer.vue
@@ -57,6 +57,18 @@ const data = computed(() => {
       return []
   }
 })
+const downloadData = computed(() => {
+  switch (props.tabname) {
+    case CONSTANTS.REPORTING_TAB.MODEL_REPORT:
+        return [...projectionStore.csvYieldLines]
+    case CONSTANTS.REPORTING_TAB.VIEW_ERR_MSG:
+      return [...projectionStore.errorMessages]
+    case CONSTANTS.REPORTING_TAB.VIEW_LOG_FILE:
+      return [...projectionStore.logMessages]
+    default:
+      return []
+  }
+})
 
 const rawResults = computed(() => {
   if (props.tabname === CONSTANTS.REPORTING_TAB.MODEL_REPORT) {
@@ -75,14 +87,11 @@ const handleDownload = () => {
   }
   switch (props.tabname) {
     case CONSTANTS.REPORTING_TAB.MODEL_REPORT:
-      if (
-        appStore.modelSelection ===
-        CONSTANTS.MODEL_SELECTION.INPUT_MODEL_PARAMETERS
-      ) {
-        downloadTextFile(data.value, CONSTANTS.FILE_NAME.YIELD_TABLE_TXT)
-      } else {
-        downloadCSVFile(data.value, CONSTANTS.FILE_NAME.YIELD_TABLE_CSV)
+      if (!downloadData.value || downloadData.value.length === 0) {
+        messageHandler.logErrorMessage(MESSAGE.FILE_DOWNLOAD_ERR.NO_DATA)
+        return
       }
+      downloadCSVFile(downloadData.value, CONSTANTS.FILE_NAME.YIELD_TABLE_CSV)
       break
     case CONSTANTS.REPORTING_TAB.VIEW_ERR_MSG:
       downloadTextFile(data.value, CONSTANTS.FILE_NAME.ERROR_TXT)

--- a/frontend/src/services/modelParameterService.ts
+++ b/frontend/src/services/modelParameterService.ts
@@ -397,6 +397,7 @@ const buildExecutionOptions = (
     ExecutionOptionsEnum.DoEnableProgressLogging,
     ExecutionOptionsEnum.DoEnableErrorLogging,
     ExecutionOptionsEnum.DoEnableDebugLogging,
+    ExecutionOptionsEnum.DoEnableProjectionReport,
     ExecutionOptionsEnum.AllowAggressiveValueEstimation,
     ExecutionOptionsEnum.DoIncludeFileHeader,
     ExecutionOptionsEnum.DoSummarizeProjectionByLayer,
@@ -541,7 +542,7 @@ export const runModel = async (
         ? modelParameterStore.endYear
         : null,
     reportTitle: modelParameterStore.reportTitle,
-    outputFormat: OutputFormatEnum.TextReport,
+    outputFormat: OutputFormatEnum.CSVYieldTable,
     selectedExecutionOptions: selectedExecutionOptions,
     excludedExecutionOptions: excludedExecutionOptions,
     selectedDebugOptions: selectedDebugOptions,

--- a/frontend/src/services/vdyp-api/models/execution-options-enum.ts
+++ b/frontend/src/services/vdyp-api/models/execution-options-enum.ts
@@ -22,6 +22,7 @@ export enum ExecutionOptionsEnum {
   DoEnableProgressLogging = 'doEnableProgressLogging',
   DoEnableErrorLogging = 'doEnableErrorLogging',
   DoEnableDebugLogging = 'doEnableDebugLogging',
+  DoEnableProjectionReport = 'doEnableProjectionReport',
   DoDelayExecutionFolderDeletion = 'doDelayExecutionFolderDeletion',
   AllowAggressiveValueEstimation = 'allowAggressiveValueEstimation',
   ReportIncludeWholeStemVolume = 'reportIncludeWholeStemVolume',

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/Parameters.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/model/v1/Parameters.java
@@ -182,6 +182,7 @@ public class Parameters {
 		DO_ENABLE_PROGRESS_LOGGING("doEnableProgressLogging"), //
 		DO_ENABLE_ERROR_LOGGING("doEnableErrorLogging"), //
 		DO_ENABLE_DEBUG_LOGGING("doEnableDebugLogging"), //
+		DO_ENABLE_PROJECTION_REPORT("doEnableProjectionReport"), //
 		DO_DELAY_EXECUTION_FOLDER_DELETION("doDelayExecutionFolderDeletion"), //
 		ALLOW_AGGRESSIVE_VALUE_ESTIMATION("allowAggressiveValueEstimation"), //
 		REPORT_INCLUDE_WHOLE_STEM_VOLUME("reportIncludeWholeStemVolume"), //

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionContext.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionContext.java
@@ -60,9 +60,7 @@ public class ProjectionContext {
 
 	private final IMessageLog progressLog;
 	private final IMessageLog errorLog;
-	private List<YieldTable> yieldTableList = new ArrayList<YieldTable>();
-	// private Optional<YieldTable> yieldTable;
-	// private YieldTable reportTable = null;
+	private List<YieldTable> yieldTableList = new ArrayList<>();
 
 	private ExecutorService executorService;
 	private FileSystem resourceFileSystem;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionContext.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionContext.java
@@ -12,10 +12,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -59,7 +60,9 @@ public class ProjectionContext {
 
 	private final IMessageLog progressLog;
 	private final IMessageLog errorLog;
-	private Optional<YieldTable> yieldTable;
+	private List<YieldTable> yieldTableList = new ArrayList<YieldTable>();
+	// private Optional<YieldTable> yieldTable;
+	// private YieldTable reportTable = null;
 
 	private ExecutorService executorService;
 	private FileSystem resourceFileSystem;
@@ -98,7 +101,6 @@ public class ProjectionContext {
 			progressLog = new NullMessageLog(Level.INFO);
 		}
 
-		this.yieldTable = Optional.empty();
 		this.executorService = Executors.newSingleThreadExecutor();
 
 		this.validatedParams = ProjectionRequestParametersValidator.validate(params, this.getRequestKind());
@@ -148,7 +150,10 @@ public class ProjectionContext {
 		startTime_ms = System.currentTimeMillis();
 
 		try {
-			getYieldTable().startGeneration();
+			createYieldTables();
+			for (YieldTable yieldTable : yieldTableList) {
+				yieldTable.startGeneration();
+			}
 		} catch (YieldTableGenerationException e) {
 			errorLog.addMessage(
 					"Encountered error starting the generation of this projection's yield table{}",
@@ -198,7 +203,9 @@ public class ProjectionContext {
 	public void endRun() {
 		try {
 			try {
-				getYieldTable().endGeneration();
+				for (YieldTable yieldTable : yieldTableList) {
+					yieldTable.endGeneration();
+				}
 			} catch (YieldTableGenerationException e) {
 				errorLog.addMessage(
 						"Encountered error starting the generation of this projection's yield table{}",
@@ -213,10 +220,8 @@ public class ProjectionContext {
 					endTime_ms - startTime_ms
 			);
 		} finally {
-			try {
-				getYieldTable().close();
-			} catch (YieldTableGenerationException e) {
-				logger.error("Encountered exception closing the yield table of projection " + projectionId, e);
+			for (YieldTable yieldTable : yieldTableList) {
+				yieldTable.close();
 			}
 		}
 	}
@@ -324,12 +329,18 @@ public class ProjectionContext {
 		return errorLog;
 	}
 
-	public YieldTable getYieldTable() throws YieldTableGenerationException {
-
-		if (yieldTable.isEmpty()) {
-			yieldTable = Optional.of(YieldTable.of(this));
+	public void createYieldTables() throws YieldTableGenerationException {
+		if (!yieldTableList.isEmpty())
+			return;
+		yieldTableList.add(YieldTable.of(this, getParams().getOutputFormat()));
+		if (getParams().getOutputFormat() != Parameters.OutputFormat.TEXT_REPORT
+				&& getParams().containsOption(ExecutionOption.DO_ENABLE_PROJECTION_REPORT)) {
+			yieldTableList.add(YieldTable.of(this, Parameters.OutputFormat.TEXT_REPORT));
 		}
-		return yieldTable.get();
+	}
+
+	public List<YieldTable> getYieldTables() {
+		return Collections.unmodifiableList(yieldTableList);
 	}
 
 	public Path getExecutionFolder() {

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunner.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunner.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.nrs.vdyp.ecore.projection;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -177,18 +176,6 @@ public class ProjectionRunner implements Closeable {
 
 	private void logApplicationMetadata() {
 		// TODO: mimic VDYP7's Console_LogMetadata
-	}
-
-	public InputStream getYieldTable() throws PolygonExecutionException {
-		if (context.isTrialRun()) {
-			return new ByteArrayInputStream(new byte[0]);
-		} else {
-			try {
-				return context.getYieldTable().getAsStream();
-			} catch (YieldTableGenerationException e) {
-				throw new PolygonExecutionException(e);
-			}
-		}
 	}
 
 	public static record ProjectionResultsKey(String polygonId, String projectionType, String entryName) {

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
@@ -64,16 +64,28 @@ public class YieldTable implements Closeable {
 	private Path yieldTableFilePath;
 
 	private int nextYieldTableNumber = 1;
+	private OutputFormat outputFormat;
 
-	private YieldTable(ProjectionContext context) throws YieldTableGenerationException {
+	public OutputFormat getOutputFormat() {
+		return outputFormat;
+	}
+
+	private YieldTable(ProjectionContext context, OutputFormat outputFormat) throws YieldTableGenerationException {
 		this.context = context;
 		this.params = context.getParams();
-		this.writer = buildYieldTableWriter(params.getOutputFormat());
+		this.writer = buildYieldTableWriter(outputFormat);
+		this.outputFormat = outputFormat;
 	}
 
 	public static YieldTable of(ProjectionContext context) throws YieldTableGenerationException {
 
-		return new YieldTable(context);
+		return new YieldTable(context, context.getParams().getOutputFormat());
+	}
+
+	public static YieldTable of(ProjectionContext context, OutputFormat outputFormat)
+			throws YieldTableGenerationException {
+
+		return new YieldTable(context, outputFormat);
 	}
 
 	public void startGeneration() throws YieldTableGenerationException {
@@ -532,7 +544,7 @@ public class YieldTable implements Closeable {
 
 				// if the format is text report we need to record the dominant species at this age for the Site Curve
 				// table from the report
-				if (context.getParams().getOutputFormat() == OutputFormat.TEXT_REPORT) {
+				if (outputFormat == OutputFormat.TEXT_REPORT) {
 					String dominantSpeciesCode = null;
 					Layer primaryLayer = polygon.findPrimaryLayerByProjectionType(ProjectionTypeCode.UNKNOWN);
 					if (primaryLayer != null

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -138,7 +137,8 @@ public class PolygonProjectionRunnerTest {
 		var unit = PolygonProjectionRunner.of(polygon, context, componentRunner);
 		unit.project();
 		String progress = new String(context.getProgressLog().getAsStream().readAllBytes());
-		YieldTable yieldTable = context.getYieldTable();
+		context.createYieldTables();
+		YieldTable yieldTable = context.getYieldTables().get(0);
 		yieldTable.startGeneration();
 		yieldTable.endGeneration();
 
@@ -155,10 +155,12 @@ public class PolygonProjectionRunnerTest {
 		polygon.doCompleteDefinition(context);
 		var componentRunner = new RealComponentRunner();
 		var unit = PolygonProjectionRunner.of(polygon, context, componentRunner);
+
+		// Need to start the run in the context before projection to provide yield tables to fill
+		context.startRun();
 		unit.project();
-		YieldTable yieldTable = context.getYieldTable();
-		yieldTable.startGeneration();
-		yieldTable.endGeneration();
+		context.endRun();
+		YieldTable yieldTable = context.getYieldTables().get(0);
 
 		var content = new String(yieldTable.getAsStream().readAllBytes());
 		assertThat(content.length(), greaterThan(0));

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunnerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunnerTest.java
@@ -19,6 +19,7 @@ import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestExcep
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProgressFrequency;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.projection.output.yieldtable.YieldTable;
 import ca.bc.gov.nrs.vdyp.ecore.utils.ParameterNames;
 import ca.bc.gov.nrs.vdyp.test.TestUtils;
 
@@ -121,7 +122,8 @@ public class ProjectionRunnerTest {
 		);
 		unit.run(streams);
 
-		String results = new String(unit.getYieldTable().readAllBytes());
+		YieldTable yieldTable = unit.getContext().getYieldTables().get(0);
+		String results = new String(yieldTable.getAsStream().readAllBytes());
 		assertThat(results.length(), greaterThan(0));
 		assertThat(results, containsString("CFS_BIO"));
 	}
@@ -152,7 +154,8 @@ public class ProjectionRunnerTest {
 		);
 		unit.run(streams);
 
-		String results = new String(unit.getYieldTable().readAllBytes());
+		YieldTable yieldTable = unit.getContext().getYieldTables().get(0);
+		String results = new String(yieldTable.getAsStream().readAllBytes());
 		assertThat(results.length(), greaterThan(0));
 		assertThat(results, containsString("MoF_BIO"));
 	}
@@ -180,7 +183,8 @@ public class ProjectionRunnerTest {
 				layersInputStream
 		);
 		unit.run(streams);
-		String results = new String(unit.getYieldTable().readAllBytes());
+		YieldTable yieldTable = unit.getContext().getYieldTables().get(0);
+		String results = new String(yieldTable.getAsStream().readAllBytes());
 		assertThat(results.length(), greaterThan(0));
 	}
 


### PR DESCRIPTION
Enabling multiple yield table output as a generic solution. The use case is if a Text report is requested along with the yield table it will generate that table from the data as well. 

It will only generate the report if a report was not the requested yield table type and the report was directly requested via a new execution option