### PR TITLE
VDYP-784: Add warning message about By Species being a CSV only setting

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
@@ -537,6 +537,10 @@ class FullReportYieldTableWriter extends YieldTableWriter<TextYieldTableRowValue
 	private void writeNotes() throws YieldTableGenerationException {
 		// WHERE ARE THE NOTES STORED? DO WE STORE THEM?
 		doWrite("\n");
+
+		if (context.getParams().containsOption(ExecutionOption.DO_INCLUDE_SPECIES_PROJECTION)) {
+			doWrite("%s\n", "WARN: By Species values are only visible in the CSV version of the Yield Table");
+		}
 		List<PolygonMessage> messages = lastPolygonForTrailer.getMessages();
 		for (PolygonMessage message : messages) {
 			doWrite("%s\n", message.getSimpleMessageText());

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -853,7 +854,8 @@ class YieldTableTest {
 								Parameters.ExecutionOption.REPORT_INCLUDE_ND_WAST_BRKG_VOLUME, //
 								Parameters.ExecutionOption.REPORT_INCLUDE_CULMINATION_VALUES, //
 								Parameters.ExecutionOption.REPORT_INCLUDE_VOLUME_MAI,
-								Parameters.ExecutionOption.DO_INCLUDE_SECONDARY_SPECIES_DOMINANT_HEIGHT_IN_YIELD_TABLE
+								Parameters.ExecutionOption.DO_INCLUDE_SECONDARY_SPECIES_DOMINANT_HEIGHT_IN_YIELD_TABLE,
+								Parameters.ExecutionOption.DO_INCLUDE_SPECIES_PROJECTION
 						),
 						"My Testing VDYP Yield Table Report that is longer than 80 characters so that it will be wrapped in the output"
 				),
@@ -946,6 +948,21 @@ class YieldTableTest {
 		assertThat(content, containsString("Species Parameters..."));
 		assertThat(content, containsString("Site Index Curves Used..."));
 		assertThat(content, containsString("Additional Stand Attributes:"));
+		if (options.contains(Parameters.ExecutionOption.DO_INCLUDE_SPECIES_PROJECTION)) {
+			assertThat(
+					content,
+					containsString("WARN: By Species values are only visible in the CSV version of the Yield Table")
+			);
+		} else {
+			assertThat(
+					content,
+					not(
+							containsString(
+									"WARN: By Species values are only visible in the CSV version of the Yield Table"
+							)
+					)
+			);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Add a warning to the Text Report regarding the absence of By Species.