### PR TITLE
Feature/VDYP-792

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
@@ -74,21 +74,25 @@ public class CSVYieldTableRowValuesBean implements YieldTableRowBean {
 //  { "(TABLE_NUM)"(,                      csvFldType_LONG,   10, 0, "", TRUE },  /* csvYldTbl_TblNum                       */)
 	@CsvBindByName(column = "TABLE_NUM")
 	@CsvBindByPosition(position = 0)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String tableNumber;
 
 //  { "(FEATURE_ID)"(,                     csvFldType_CHAR,   38, 0, "", TRUE },  /* csvYldTbl_FeatureID                    */)
 	@CsvBindByName(column = "FEATURE_ID")
 	@CsvBindByPosition(position = 1)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String featureId;
 
 //  { "(DISTRICT)"(,                       csvFldType_CHAR,    3, 0, "", TRUE },  /* csvYldTbl_District                     */)
 	@CsvBindByName(column = "DISTRICT")
 	@CsvBindByPosition(position = 2)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String district;
 
 //  { "(MAP_ID)"(,                         csvFldType_CHAR,    9, 0, "", TRUE },  /* csvYldTbl_MapID                        */)
 	@CsvBindByName(column = "MAP_ID")
 	@CsvBindByPosition(position = 3)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String mapId;
 
 //  { "(POLYGON_ID)"(,                     csvFldType_LONG,   10, 0, "", TRUE },  /* csvYldTbl_PolygonID                    */)
@@ -100,11 +104,13 @@ public class CSVYieldTableRowValuesBean implements YieldTableRowBean {
 //  { "(LAYER_ID)"(,                       csvFldType_CHAR,    1, 0, "", TRUE },  /* csvYldTbl_LayerID                      */)
 	@CsvBindByName(column = "LAYER_ID")
 	@CsvBindByPosition(position = 5)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String layerId;
 
 //  { "(PROJECTION_YEAR)"(,                csvFldType_SHORT,   4, 0, "", TRUE },  /* csvYldTbl_ProjectionYear               */)
 	@CsvBindByName(column = "PROJECTION_YEAR")
 	@CsvBindByPosition(position = 6)
+	@OptionalField(category = YieldTable.Category.FILE_UPLOAD_METADATA)
 	private String projectionYear;
 
 //  { "(PRJ_TOTAL_AGE)"(,                  csvFldType_SHORT,   4, 0, "", TRUE },  /* csvYldTbl_ProjectionTotalAge           */)

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
@@ -52,7 +52,7 @@ public class YieldTable implements Closeable {
 
 	public enum Category {
 		LAYER_MOFVOLUMES, LAYER_MOFBIOMASS, SPECIES_MOFVOLUME, SPECIES_MOFBIOMASS, CFSBIOMASS, PROJECTION_MODE,
-		POLYGON_ID, SECONDARY_HEIGHT, NONE
+		POLYGON_ID, SECONDARY_HEIGHT, FILE_UPLOAD_METADATA, NONE
 	}
 
 	private static final Logger logger = LoggerFactory.getLogger(YieldTable.class);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableWriter.java
@@ -320,6 +320,9 @@ abstract class YieldTableWriter<T extends YieldTableRowBean> implements Closeabl
 		)) {
 			currentCategories.add(YieldTable.Category.SECONDARY_HEIGHT);
 		}
+		if (!params.containsOption(Parameters.ExecutionOption.DO_ENABLE_PROJECTION_REPORT)) {
+			currentCategories.add(YieldTable.Category.FILE_UPLOAD_METADATA);
+		}
 	}
 
 	public boolean isCurrentlyWritingCategory(YieldTable.Category category) {

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -995,7 +995,160 @@ class YieldTableTest {
 
 		assertThrows(
 				StandYieldCalculationException.class,
-				() -> yieldTable.getYields(2020, UtilizationClassSet._7_5, species, null)
-		);
+				() -> yieldTable.getYields(2020, UtilizationClassSet._7_5, species, null));
+	}
+
+	@Test
+	void testCSVYieldTableFileUploadMode_IncludesMetadataColumns()
+			throws AbstractProjectionRequestException, IOException {
+
+		// File Upload mode: DO_ENABLE_PROJECTION_REPORT is NOT included
+		var parameters = testHelper.addSelectedOptions(
+				new Parameters(), //
+				Parameters.ExecutionOption.DO_INCLUDE_PROJECTED_MOF_VOLUMES, //
+				Parameters.ExecutionOption.DO_SUMMARIZE_PROJECTION_BY_LAYER, //
+				Parameters.ExecutionOption.DO_INCLUDE_POLYGON_RECORD_ID_IN_YIELD_TABLE, //
+				Parameters.ExecutionOption.DO_INCLUDE_FILE_HEADER);
+		parameters.setYearStart(2025);
+		parameters.setYearEnd(2030);
+		parameters.setOutputFormat(Parameters.OutputFormat.CSV_YIELD_TABLE);
+
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
+
+		var polygonInputStream = TestUtils.makeInputStream(
+				//
+				POLYGON_CSV_HEADER_LINE,
+				"13919428,093C090,94833422,DQU,UNK,UNK,V,UNK,0.6,10,3,HE,35,8,,MS,14,50.0,1.000,NP,V,T,U,TC,SP,2013,2013,60.0,,,,,,,,,,TC,100,,,,");
+		var layersInputStream = TestUtils.makeInputStream(
+				//
+				LAYER_CSV_HEADER_LINE,
+				"13919428,14321066,093C090,94833422,1,P,,1,,,,20,10.000010,300,PLI,60.00,SX,40.00,,,,,,,,,180,18.00,180,23.00,,,,,,,,");
+
+		var polygonStream = new HcsvPolygonStream(context, polygonInputStream, layersInputStream);
+
+		var polygon = polygonStream.getNextPolygon();
+
+		var yieldTable = YieldTable.of(context);
+		try {
+			yieldTable.startGeneration();
+
+			var state = new PolygonProjectionState();
+			state.setProcessingResults(ProjectionStageCode.Initial, ProjectionTypeCode.PRIMARY, Optional.empty());
+			state.setProcessingResults(ProjectionStageCode.Forward, ProjectionTypeCode.PRIMARY, Optional.empty());
+
+			var vdypPolygonStreamFile = testHelper.getResourceFile(relativeResourcePath, "vp_grow.dat");
+			var vdypPolygonStream = Files.newInputStream(vdypPolygonStreamFile);
+			var vdypSpeciesStreamFile = testHelper.getResourceFile(relativeResourcePath, "vs_grow.dat");
+			var vdypSpeciesStream = Files.newInputStream(vdypSpeciesStreamFile);
+			var vdypUtilizationsStreamFile = testHelper.getResourceFile(relativeResourcePath, "vu_grow.dat");
+			var vdypUtilizationsStream = Files.newInputStream(vdypUtilizationsStreamFile);
+
+			ProjectionResultsReader forwardReader = new TestProjectionResultsReader(
+					testHelper, vdypPolygonStream, vdypSpeciesStream, vdypUtilizationsStream);
+			ProjectionResultsReader backReader = new NullProjectionResultsReader();
+
+			var projectionResults = ProjectionResultsBuilder
+					.read(polygon, state, ProjectionTypeCode.PRIMARY, forwardReader, backReader);
+
+			for (var layerReportingInfo : polygon.getReportingInfo().getLayerReportingInfos().values()) {
+				var layer = layerReportingInfo.getLayer();
+				if (state.layerWasProjected(layer)) {
+					yieldTable.generateYieldTableForPolygonLayer(
+							polygon, projectionResults, state, layerReportingInfo, false);
+				}
+			}
+		} finally {
+			yieldTable.endGeneration();
+			yieldTable.close();
+		}
+
+		var content = new String(yieldTable.getAsStream().readAllBytes());
+
+		// Verify that File Upload mode includes all 6 metadata columns
+		assertThat(content, containsString("TABLE_NUM"));
+		assertThat(content, containsString("FEATURE_ID"));
+		assertThat(content, containsString("DISTRICT"));
+		assertThat(content, containsString("MAP_ID"));
+		assertThat(content, containsString("POLYGON_ID"));
+		assertThat(content, containsString("LAYER_ID"));
+		assertThat(content, containsString("PROJECTION_YEAR"));
+	}
+
+	@Test
+	void testCSVYieldTableInputModelParametersMode_ExcludesMetadataColumns()
+			throws AbstractProjectionRequestException, IOException {
+
+		// Input Model Parameters mode: DO_ENABLE_PROJECTION_REPORT is included
+		var parameters = testHelper.addSelectedOptions(
+				new Parameters(), //
+				Parameters.ExecutionOption.DO_INCLUDE_PROJECTED_MOF_VOLUMES, //
+				Parameters.ExecutionOption.DO_SUMMARIZE_PROJECTION_BY_LAYER, //
+				Parameters.ExecutionOption.DO_ENABLE_PROJECTION_REPORT, // This triggers Input Model Parameters mode
+				Parameters.ExecutionOption.DO_INCLUDE_FILE_HEADER);
+		parameters.setYearStart(2025);
+		parameters.setYearEnd(2030);
+		parameters.setOutputFormat(Parameters.OutputFormat.CSV_YIELD_TABLE);
+
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
+
+		var polygonInputStream = TestUtils.makeInputStream(
+				//
+				POLYGON_CSV_HEADER_LINE,
+				"13919428,093C090,94833422,DQU,UNK,UNK,V,UNK,0.6,10,3,HE,35,8,,MS,14,50.0,1.000,NP,V,T,U,TC,SP,2013,2013,60.0,,,,,,,,,,TC,100,,,,");
+		var layersInputStream = TestUtils.makeInputStream(
+				//
+				LAYER_CSV_HEADER_LINE,
+				"13919428,14321066,093C090,94833422,1,P,,1,,,,20,10.000010,300,PLI,60.00,SX,40.00,,,,,,,,,180,18.00,180,23.00,,,,,,,,");
+
+		var polygonStream = new HcsvPolygonStream(context, polygonInputStream, layersInputStream);
+
+		var polygon = polygonStream.getNextPolygon();
+
+		var yieldTable = YieldTable.of(context);
+		try {
+			yieldTable.startGeneration();
+
+			var state = new PolygonProjectionState();
+			state.setProcessingResults(ProjectionStageCode.Initial, ProjectionTypeCode.PRIMARY, Optional.empty());
+			state.setProcessingResults(ProjectionStageCode.Forward, ProjectionTypeCode.PRIMARY, Optional.empty());
+
+			var vdypPolygonStreamFile = testHelper.getResourceFile(relativeResourcePath, "vp_grow.dat");
+			var vdypPolygonStream = Files.newInputStream(vdypPolygonStreamFile);
+			var vdypSpeciesStreamFile = testHelper.getResourceFile(relativeResourcePath, "vs_grow.dat");
+			var vdypSpeciesStream = Files.newInputStream(vdypSpeciesStreamFile);
+			var vdypUtilizationsStreamFile = testHelper.getResourceFile(relativeResourcePath, "vu_grow.dat");
+			var vdypUtilizationsStream = Files.newInputStream(vdypUtilizationsStreamFile);
+
+			ProjectionResultsReader forwardReader = new TestProjectionResultsReader(
+					testHelper, vdypPolygonStream, vdypSpeciesStream, vdypUtilizationsStream);
+			ProjectionResultsReader backReader = new NullProjectionResultsReader();
+
+			var projectionResults = ProjectionResultsBuilder
+					.read(polygon, state, ProjectionTypeCode.PRIMARY, forwardReader, backReader);
+
+			for (var layerReportingInfo : polygon.getReportingInfo().getLayerReportingInfos().values()) {
+				var layer = layerReportingInfo.getLayer();
+				if (state.layerWasProjected(layer)) {
+					yieldTable.generateYieldTableForPolygonLayer(
+							polygon, projectionResults, state, layerReportingInfo, false);
+				}
+			}
+		} finally {
+			yieldTable.endGeneration();
+			yieldTable.close();
+		}
+
+		var content = new String(yieldTable.getAsStream().readAllBytes());
+
+		// Verify that Input Model Parameters mode EXCLUDES the 6 metadata columns
+		assertThat(content, not(containsString("TABLE_NUM")));
+		assertThat(content, not(containsString("FEATURE_ID")));
+		assertThat(content, not(containsString("DISTRICT")));
+		assertThat(content, not(containsString("MAP_ID")));
+		assertThat(content, not(containsString("LAYER_ID")));
+		assertThat(content, not(containsString("PROJECTION_YEAR")));
+
+		assertThat(content, containsString("PRJ_TOTAL_AGE"));
+		assertThat(content, containsString("SPECIES_1_CODE"));
 	}
 }


### PR DESCRIPTION
VDYP-792: Input Model Parameters - Yield Table should not display first six columns

When a yield table is generated and accessed from an Input Model Parameters projection it should not include the following columns:
1. TABLE_NUM
2. FEATURE_ID
3. DISTRICT
4. MAP_ID
5. LAYER_ID
6. PROJECTION_YEAR

These columns are related to File Upload projection.  An Input Model Parameters projection is not aware of maps, polygons, layers or years.  

TAC:
A Input Model Parameters generated Yield Table should not show columns related to map, polygon, layer or year (e.g. first 6 columns)